### PR TITLE
feat: add YAML support for config API

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ For Docker you can mount a local file into the container:
 docker run -v $(pwd)/mock-llm.yaml:/app/mock-llm.yaml -p 8080:8080 ghcr.io/dwmkerr/mock-llm
 ```
 
+### Health & Readiness Checks
+
+```bash
+curl http://localhost:8080/health
+# {"status":"healthy"}
+
+curl http://localhost:8080/ready
+# {"status":"ready"}
+```
+
 ### Updating Configuration
 
 Configuration can be updated at runtime via the `/config` endpoint: `GET` returns current config (JSON by default, YAML with `Accept: application/x-yaml`), `POST` replaces it, `PATCH` merges updates, `DELETE` resets to default. Both `POST` and `PATCH` accept JSON (`Content-Type: application/json`) or YAML (`Content-Type: application/x-yaml`).

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,4 +17,4 @@ const app = createServer(config);
 
 app.listen(PORT, HOST, () => {
   console.log(`mock-llm server running on ${HOST}:${PORT}`);
-});
+}).on('error', (err) => { console.error(err); process.exit(1); });

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -20,6 +20,20 @@ describe('server config API', () => {
     server.close(done);
   });
 
+  it('should GET /health', async () => {
+    const response = await fetch(`${baseUrl}/health`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'healthy' });
+  });
+
+  it('should GET /ready', async () => {
+    const response = await fetch(`${baseUrl}/ready`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ready' });
+  });
+
   it('should GET current config as JSON by default', async () => {
     const response = await fetch(`${baseUrl}/config`);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,14 @@ export function createServer(initialConfig: Config) {
     next();
   });
 
+  //  Health and readiness checks
+  app.get('/health', (_, res) => {
+    res.json({ status: 'healthy' });
+  });
+  app.get('/ready', (_, res) => {
+    res.json({ status: 'ready' });
+  });
+
   //  Handle config requests (get/replace/update/delete).
   app.get('/config', (req, res) => {
     // Return YAML if Accept header requests it, otherwise JSON


### PR DESCRIPTION
## Summary
- Add YAML response format for GET `/config` with `Accept: application/x-yaml` header
- Add 401 error sample demonstrating YAML config input
- Add unit tests validating JSON and YAML response formats