### PR TITLE
fix: replace Handlebars with custom template engine for JMESPath compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,13 @@ Configuration can be updated at runtime via the `/config` endpoint: `GET` return
 
 Available in response content templates:
 
-- `{{jmes request 'path'}}` - Query the request body using JMESPath
+- `{{jmes request path}}` - Query the request body using JMESPath. Primitives (strings, numbers, booleans) are returned as-is. Objects and arrays are automatically JSON-stringified.
+- `{{timestamp}}` - Current time in milliseconds
+
+```yaml
+"model": "{{jmes request model}}"              // outputs: "model": "gpt-4"
+"message": {{jmes request messages[0]}}        // outputs: "message": {"role":"system","content":"..."}
+```
 
 ## Examples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",
-        "handlebars": "^4.7.8",
         "jmespath": "^0.16.0",
         "js-yaml": "^4.1.0",
         "openai": "^4.28.0"
       },
       "bin": {
-        "mock-llm": "dist/server.js"
+        "mock-llm": "dist/main.js"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -4023,6 +4022,7 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -5320,6 +5320,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5351,6 +5352,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-domexception": {
@@ -6324,6 +6326,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6795,6 +6798,7 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -6958,6 +6962,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "handlebars": "^4.7.8",
     "jmespath": "^0.16.0",
     "js-yaml": "^4.1.0",
     "openai": "^4.28.0"

--- a/samples/03-system-message-in-conversation.sh
+++ b/samples/03-system-message-in-conversation.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Returns the system message (messages[0]) to validate agent configuration.
+# Useful for testing parameter resolution in agent prompts.
+
+# Configure mock-llm to return the first message (system message).
+curl -fsSL -X POST http://localhost:8080/config \
+  -H "Content-Type: application/x-yaml" \
+  -d '
+rules:
+  - path: "/v1/chat/completions"
+    match: "@"
+    response:
+      status: 200
+      content: |
+        {
+          "object": "chat.completion",
+          "model": "{{jmes request model}}",
+          "choices": [{
+            "message": {{jmes request messages[0]}},
+            "finish_reason": "stop"
+          }]
+        }' > /dev/null
+
+# Send a conversation with system message, user message, and assistant response.
+response=$(curl -fsSL -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant. Always respond in French."},
+      {"role": "user", "content": "Hello"},
+      {"role": "assistant", "content": "Bonjour!"}
+    ]
+  }')
+
+# Expected response with system message.
+expected='{
+  "object": "chat.completion",
+  "model": "gpt-4",
+  "choices": [{
+    "message": {
+      "role": "system",
+      "content": "You are a helpful assistant. Always respond in French."
+    },
+    "finish_reason": "stop"
+  }]
+}'
+
+# Fail if response doesn't match expected.
+diff_output=$(diff <(echo "$expected" | jq -S .) <(echo "$response" | jq -S .) 2>&1) && echo "passed" || { echo -e "failed:\n${diff_output}"; exit 1; }

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,11 +28,11 @@ export function getDefaultConfig(): Config {
           content: `{
   "id": "chatcmpl-{{timestamp}}",
   "object": "chat.completion",
-  "model": "{{jmes request 'model'}}",
+  "model": "{{jmes request model}}",
   "choices": [{
     "message": {
       "role": "assistant",
-      "content": "{{jmes request 'messages[-1].content'}}"
+      "content": "{{jmes request messages[-1].content}}"
     },
     "finish_reason": "stop"
   }]

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,5 +16,6 @@ console.log(`Loaded configuration from ${configPath} - ${config.rules.length} ru
 const app = createServer(config);
 
 app.listen(PORT, HOST, () => {
+  //  TODO: why not the package.name and package.version import json and use that.
   console.log(`mock-llm server running on ${HOST}:${PORT}`);
 }).on('error', (err) => { console.error(err); process.exit(1); });

--- a/src/template.spec.ts
+++ b/src/template.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from '@jest/globals';
+import { renderTemplate } from './template';
+
+describe('template', () => {
+  it('should replace timestamp', () => {
+    const result = renderTemplate('{"time":"{{timestamp}}"}', {});
+    const parsed = JSON.parse(result);
+
+    expect(typeof parsed.time).toBe('string');
+    expect(parseInt(parsed.time)).toBeGreaterThan(0);
+  });
+
+  it('should replace jmes with primitive', () => {
+    const result = renderTemplate(
+      '{"model":"{{jmes request model}}"}',
+      { request: { model: 'gpt-4' } }
+    );
+
+    expect(JSON.parse(result)).toEqual({ model: 'gpt-4' });
+  });
+
+  it('should replace jmes with object', () => {
+    const result = renderTemplate(
+      '{"message":{{jmes request messages[0]}}}',
+      { request: { messages: [{ role: 'system', content: 'Test' }] } }
+    );
+
+    expect(JSON.parse(result)).toEqual({
+      message: { role: 'system', content: 'Test' }
+    });
+  });
+
+  it('should handle multiple replacements', () => {
+    const result = renderTemplate(
+      '{"time":"{{timestamp}}","model":"{{jmes request model}}"}',
+      { request: { model: 'gpt-4' } }
+    );
+
+    const parsed = JSON.parse(result);
+    expect(parsed.model).toBe('gpt-4');
+    expect(typeof parsed.time).toBe('string');
+  });
+});

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,0 +1,21 @@
+import * as jmespath from 'jmespath';
+
+export function renderTemplate(template: string, context: Record<string, unknown>): string {
+  let result = template;
+
+  // Replace {{timestamp}} with current milliseconds
+  result = result.replace(/\{\{timestamp\}\}/g, () => Date.now().toString());
+
+  // Replace {{jmes contextKey path}} with JMESPath query result
+  result = result.replace(/\{\{jmes\s+(\w+)\s+([^}]+)\}\}/g, (_, contextKey, path) => {
+    const obj = context[contextKey];
+    const value = jmespath.search(obj, path);
+
+    if (typeof value === 'object' && value !== null) {
+      return JSON.stringify(value);
+    }
+    return String(value);
+  });
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Replace Handlebars with custom template engine to fix JMESPath bracket syntax conflicts
- Add `samples/03-system-message-in-conversation.sh` demonstrating system message return
- Simplify template syntax: `{{jmes request messages[0]}}` (no quotes needed)
- Remove handlebars dependency