### PR TITLE
feat: add Helm documentation and Ark Model CRD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ config:
 # existingConfigMap: "my-custom-config"
 ```
 
+See the [full Helm documentation](docs/helm.md) for advanced configuration, Ark integration, and more.
+
 ## Examples
 
 Any OpenAI API compatible SDKs can be used with Mock LLM. For Node.js:

--- a/chart/templates/ark/model.yaml
+++ b/chart/templates/ark/model.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ark.model.enabled -}}
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+metadata:
+  name: {{ .Values.ark.model.name }}
+  labels:
+    {{- include "mock-llm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.ark.model.type }}
+  model:
+    value: {{ .Values.ark.model.model }}
+  pollInterval: {{ .Values.ark.model.pollInterval }}
+  config:
+    {{- if eq .Values.ark.model.type "openai" }}
+    openai:
+      baseUrl:
+        value: http://{{ include "mock-llm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/v1
+      apiKey:
+        value: {{ .Values.ark.model.apiKey }}
+    {{- else if eq .Values.ark.model.type "azure" }}
+    azure:
+      baseUrl:
+        value: http://{{ include "mock-llm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+      apiKey:
+        value: {{ .Values.ark.model.apiKey }}
+      apiVersion:
+        value: "2024-12-01-preview"
+    {{- else if eq .Values.ark.model.type "bedrock" }}
+    bedrock:
+      baseUrl:
+        value: http://{{ include "mock-llm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+      apiKey:
+        value: {{ .Values.ark.model.apiKey }}
+    {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -190,3 +190,20 @@ affinity: {}
 
 # Use an existing ConfigMap instead of creating one from config above
 # existingConfigMap: ""
+
+# Ark Model CRD configuration (optional)
+# Requires Ark to be installed: https://github.com/mckinsey/agents-at-scale
+ark:
+  model:
+    # Enable creation of Ark Model resource. Requires Ark CRDs to be installed.
+    enabled: false
+    # Model name
+    name: "gpt-5"
+    # Model type (openai, azure, or bedrock)
+    type: "openai"
+    # Model identifier
+    model: "gpt-5"
+    # Poll interval for health checks
+    pollInterval: "3s"
+    # API key for mock service
+    apiKey: "mock-api-key"

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,0 +1,127 @@
+# Helm Chart Documentation
+
+This guide covers deploying mock-llm to Kubernetes using Helm.
+
+## Installation
+
+Install from the OCI registry:
+
+```bash
+helm install mock-llm oci://ghcr.io/dwmkerr/charts/mock-llm --version 0.1.8
+```
+
+Verify the deployment:
+
+```bash
+kubectl get deployment mock-llm
+kubectl get service mock-llm
+```
+
+Test the service:
+
+```bash
+kubectl port-forward svc/mock-llm 8080:8080 &
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+## Configuration
+
+### Custom Mock Rules
+
+Configure custom responses via `values.yaml`:
+
+```yaml
+# Optional additional mock-llm configuration.
+config:
+  rules:
+    - path: "/v1/chat/completions"
+      match: "contains(messages[-1].content, 'hello')"
+      response:
+        status: 200
+        content: |
+          {
+            "choices": [{
+              "message": {
+                "role": "assistant",
+                "content": "Hi there!"
+              },
+              "finish_reason": "stop"
+            }]
+          }
+```
+
+Install with custom configuration:
+
+```bash
+helm install mock-llm oci://ghcr.io/dwmkerr/charts/mock-llm \
+  --values custom-values.yaml
+```
+
+### Using Existing ConfigMap
+
+If you manage your configuration separately:
+
+```yaml
+# Use existing ConfigMap (must contain key 'mock-llm.yaml')
+existingConfigMap: "my-custom-config"
+```
+
+## Installing on Ark
+
+[Ark](https://github.com/mckinsey/agents-at-scale-ark) is an agentic AI platform for Kubernetes. Mock-llm can be used with Ark's Model CRD. This is useful for:
+
+- Deterministic testing
+- Testing error scenarios
+- Understanding values sent to the LLM (e.g. expanded parameters etc)
+- Eliminating costs
+- Eliminating inference time for tests
+
+To install the Ark model, the Ark CRDs must be installed. Check the [Ark Documentation](https://mckinsey.github.io/agents-at-scale-ark/) for details
+
+Example: Create an Azure OpenAI model pointing to mock-llm:
+
+```yaml
+# values.yaml
+ark:
+  model:
+    enabled: true
+    name: "gpt-5"
+    type: "azure"
+    model: "gpt-5"
+    pollInterval: "3s"
+    apiKey: "mock-api-key"
+```
+
+This creates an Ark Model CRD that points to the mock-llm service. Agents can then reference this model for testing.
+
+Mock-llm supports mocking OpenAI, Azure OpenAI, and AWS Bedrock model types. See the [Ark examples](https://github.com/mckinsey/agents-at-scale/tree/main/tests) for more usage patterns.
+
+## Chart Values
+
+Key configuration options:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of replicas | `1` |
+| `image.repository` | Container image repository | `ghcr.io/dwmkerr/mock-llm` |
+| `image.tag` | Container image tag | Chart appVersion |
+| `service.type` | Kubernetes service type | `ClusterIP` |
+| `service.port` | Service port | `8080` |
+| `config` | Mock LLM configuration rules | `nil` (uses defaults) |
+| `existingConfigMap` | Use existing ConfigMap for config | `""` |
+| `ark.model.enabled` | Create Ark `model` resource (requires Ark CRDs to be installed) | `false` |
+| `ark.model.name` | Model name | `"gpt-5"` |
+| `ark.model.type` | Model type (openai/azure/bedrock) | `"openai"` |
+| `ark.model.model` | Model identifier | `"gpt-5"` |
+
+See [values.yaml](../chart/values.yaml) for all available options.
+
+## Uninstalling
+
+Remove the release:
+
+```bash
+helm uninstall mock-llm
+```


### PR DESCRIPTION
## Summary
- Adds comprehensive Helm documentation in `docs/helm.md` with installation, configuration, and Ark integration examples
- Adds optional Ark Model CRD template for testing without LLM costs
- Supports OpenAI, Azure OpenAI, and AWS Bedrock model types
- Updates README to link to full Helm documentation

## Test plan
- [x] Helm lint passes
- [x] Template renders without ark.model.enabled (no Model CRD created)
- [x] Template renders with ark.model.enabled for OpenAI type
- [x] Template renders with ark.model.enabled for Azure type
- [x] Service URL auto-wired to deployed mock-llm service