### PR TITLE
fix: include service port in Ark Model baseUrl

### DIFF
--- a/chart/templates/ark/model.yaml
+++ b/chart/templates/ark/model.yaml
@@ -14,13 +14,13 @@ spec:
     {{- if eq .Values.ark.model.type "openai" }}
     openai:
       baseUrl:
-        value: http://{{ include "mock-llm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/v1
+        value: http://{{ include "mock-llm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/v1
       apiKey:
         value: {{ .Values.ark.model.apiKey }}
     {{- else if eq .Values.ark.model.type "azure" }}
     azure:
       baseUrl:
-        value: http://{{ include "mock-llm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+        value: http://{{ include "mock-llm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
       apiKey:
         value: {{ .Values.ark.model.apiKey }}
       apiVersion:
@@ -28,7 +28,7 @@ spec:
     {{- else if eq .Values.ark.model.type "bedrock" }}
     bedrock:
       baseUrl:
-        value: http://{{ include "mock-llm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+        value: http://{{ include "mock-llm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
       apiKey:
         value: {{ .Values.ark.model.apiKey }}
     {{- end }}


### PR DESCRIPTION
## Summary
- Fixes Ark Model CRD baseUrl to include service port `:8080`

## Problem
ARK's Model controller could not connect to mock-llm because the baseUrl was missing the port number:
```yaml
baseUrl: http://mock-llm.namespace.svc.cluster.local/v1
```

This caused HTTP clients to default to port 80, but the service runs on port 8080, resulting in 30-second connection timeouts.

## Solution
Updated the Helm template to include the service port from values:
```yaml
baseUrl: http://mock-llm.namespace.svc.cluster.local:8080/v1
```

## Test plan
- [x] Helm template renders correctly with port included
- [ ] Wait for CI to pass