### PR TITLE
fix: return 404 AgentNotFound for missing A2A agents

### DIFF
--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -151,6 +151,17 @@ describe('server error handling', () => {
     });
   });
 
+  it('should return AgentNotFound for missing A2A agents', async () => {
+    const response = await fetch(`${baseUrl}/a2a/agents/nonexistent-agent`);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: 'AgentNotFound',
+      message: 'Agent not found at path: /agents/nonexistent-agent',
+      status: 404
+    });
+  });
+
   it('should return JSON 400 for malformed JSON input', async () => {
     const response = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: 'POST',

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,15 @@ export function createServer(initialConfig: Config, host: string, port: number) 
   // Setup A2A routes
   setupA2ARoutes(app, host, port);
 
+  // Catch-all for missing A2A agents
+  app.use('/a2a/', (req, res, next) => {
+    res.status(404).json({
+      error: 'AgentNotFound',
+      message: `Agent not found at path: ${req.path}`,
+      status: 404
+    });
+  });
+
   //  Health and readiness checks
   app.get('/health', (_, res) => {
     res.json({ status: 'healthy' });


### PR DESCRIPTION
- Add catch-all middleware for /a2a/* paths
- Return proper 404 error instead of generic 500
- Add unit test for missing agent error handling