### PR TITLE
fix: enhance test pod security context to address guardrails findings

### DIFF
--- a/chart/snapshots/output.yaml
+++ b/chart/snapshots/output.yaml
@@ -169,6 +169,10 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
   containers:
     - name: wget
       image: busybox
@@ -176,4 +180,8 @@ spec:
       args: ['test-chart-mock-llm:6556']
       securityContext:
         allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
   restartPolicy: Never

--- a/chart/templates/tests/test-connection.yaml
+++ b/chart/templates/tests/test-connection.yaml
@@ -7,6 +7,10 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
   containers:
     - name: wget
       image: busybox
@@ -14,4 +18,8 @@ spec:
       args: ['{{ include "mock-llm.fullname" . }}:{{ .Values.service.port }}']
       securityContext:
         allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
   restartPolicy: Never


### PR DESCRIPTION
## Summary
- Add comprehensive security hardening to Helm test connection pod
- Addresses "Privilege Escalation Allowed" guardrails security finding

## Changes
- Added pod-level security context (`runAsNonRoot`, `runAsUser`, `fsGroup`)
- Dropped all Linux capabilities
- Enabled read-only root filesystem
- Regenerated Helm chart snapshot

## Security Improvements
The test pod now matches the security posture of the main deployment with:
- Non-root user execution
- No privilege escalation
- Minimal capabilities
- Immutable filesystem