### PR TITLE
fix: only increment sequence counter when winning rule has sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Rules can use `match`, `sequence`, both, or neither:
 | No | Yes | Order-based matching only |
 | Yes | Yes | Must satisfy both conditions |
 
-Sequence counters are tracked per path and reset via `DELETE /config`.
+Sequence counters are tracked per path and reset via `DELETE /config`. The counter only increments when the winning rule has a `sequence` property, so fallback rules (without `sequence`) can handle liveness probes without consuming sequence numbers.
 
 ### Streaming Configuration
 


### PR DESCRIPTION
## Summary
- Fix bug where sequence counter incremented when any matching rule had sequence, not just the winning rule
- Add test verifying fallback rules don't consume sequences when handling liveness probes
- Update README to clarify sequence counter behavior