### PR TITLE
Allow any request type and empty body for chat completion requests

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,8 @@ export function loadConfig(configPath: string): Config {
 
   return {
     ...defaultConfig,
-    ...loadedConfig
+    ...loadedConfig,
+    // Merge rules arrays instead of replacing
+    rules: [...defaultConfig.rules, ...(loadedConfig.rules || [])]
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,7 +81,8 @@ export function createServer(initialConfig: Config, host: string, port: number) 
 
   //  Handle chat completion requests.
   app.all(/.*/, (req, res) => {
-    const requestBody: ChatCompletionCreateParamsBase = req.body || {};
+    // For GET requests, use empty object; for others, use actual body
+    const requestBody: ChatCompletionCreateParamsBase = req.method === 'GET' ? {} : (req.body || {});
     const isStreaming = requestBody.stream === true;
 
     //  Get the current sequence counter for this path.


### PR DESCRIPTION
Enable handling of GET requests for /v1/models and allow empty request bodies in chat completion requests.