### PR TITLE
feat: add MCP OAuth 2.1 emulation for protected MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The server can be configured to provide different responses based on the input, 
     - [Sequential Responses](#sequential-responses)
     - [Streaming Configuration](#streaming-configuration)
 - [MCP (Model Context Protocol) Mocking](#mcp-model-context-protocol-mocking)
+- [MCP OAuth Emulation](#mcp-oauth-emulation)
 - [A2A (Agent to Agent Protocol) Mocking](#a2a-agent-to-agent-protocol-mocking)
 - [Deploying to Kubernetes with Helm](#deploying-to-kubernetes-with-helm)
 - [Examples](#examples)
@@ -299,6 +300,10 @@ This enables deterministic testing of streaming protocol responses. Errors condi
 
 Mock-LLM exposes MCP servers and tools which support testing the MCP protocol, details are in the [MCP Documentation](docs/mcp.md).
 
+## MCP OAuth Emulation
+
+Mock-LLM can also emulate an OAuth 2.1 authorization server in front of its MCP endpoint, so you can test OAuth-protected MCP servers end-to-end without depending on a real IdP. It serves RFC 8414 / RFC 9728 discovery, RFC 7591 Dynamic Client Registration, Authorization Code + PKCE, and refresh-token flows, plus a small set of control endpoints for test orchestration. See the [MCP OAuth Documentation](docs/mcp-oauth.md).
+
 ## A2A (Agent to Agent Protocol) Mocking
 
 Mock-LLM exposes A2A servers and tools which support testing the A2A protocol, details are in the [A2A Documentation](docs/a2a.md).
@@ -411,6 +416,12 @@ npm run lint
 npm run test
 ```
 
+Run the end-to-end [samples](#samples) suite:
+
+```bash
+npm run test:samples
+```
+
 Test and inspect the MCP Server running locally:
 
 ```bash
@@ -441,6 +452,9 @@ These can be a reference for your own tests. Each sample is also run as part of 
 | [10-mcp-inspect-headers.sh](samples/10-mcp-inspect-headers.sh) | Test MCP header inspection. |
 | [11-sequential-tool-calling.sh](samples/11-sequential-tool-calling.sh) | Test sequential responses for tool-calling flows. |
 | [12-list-models.sh](samples/12-list-models.sh) | Test GET /v1/models endpoint. |
+| [14-mcp-oauth-discovery.sh](samples/14-mcp-oauth-discovery.sh) | Test OAuth 401 challenge + RFC 9728 / RFC 8414 discovery metadata on protected MCP endpoint. |
+| [15-mcp-oauth-pkce-flow.sh](samples/15-mcp-oauth-pkce-flow.sh) | Test full OAuth 2.1 Authorization Code + PKCE flow (DCR, authorize, token exchange, authenticated MCP initialize). |
+| [16-mcp-oauth-refresh.sh](samples/16-mcp-oauth-refresh.sh) | Test refresh-token grant, refresh-token rotation, and `/oauth/revoke` + `/oauth/expire` control endpoints. |
 
 Each sample below is a link to a real-world deterministic integration test in [Ark](https://github.com/mckinsey/agents-at-scale-ark) that uses `mock-llm` features. These tests can be used as a reference for your own tests.
 

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -1,0 +1,100 @@
+# MCP OAuth Emulation
+
+Mock LLM emulates an OAuth 2.1 authorization server so you can test OAuth-protected MCP servers end-to-end without hitting a real IdP (Notion, Atlassian, Linear, etc.).
+
+Target fidelity: enough to drive a controller state machine (`Required → Authorized → Expired → RefreshFailed → Required`) and a CLI OAuth flow. **Not** a general-purpose authorization server.
+
+## What's emulated
+
+Built on `@modelcontextprotocol/sdk`'s `mcpAuthRouter`, which ships the full wire protocol:
+
+| Endpoint | RFC | Served by mock-llm |
+|---|---|---|
+| `GET /.well-known/oauth-protected-resource/<path>` | RFC 9728 | yes |
+| `GET /.well-known/oauth-authorization-server` | RFC 8414 | yes |
+| `POST /register` | RFC 7591 (DCR) | yes |
+| `GET /authorize` (Authorization Code + PKCE S256, auto-approve) | RFC 6749 + 7636 | yes |
+| `POST /token` (`authorization_code`, `refresh_token`) | RFC 6749 | yes |
+| `Authorization: Bearer` gate on protected paths with RFC 9728 challenge | RFC 9728 | yes |
+
+### Explicitly out of scope
+
+- Real JWT signing (opaque tokens only).
+- User consent UI (`/authorize` auto-approves).
+- TLS (HTTP only; loopback + in-cluster).
+- RFC 7009 token revocation endpoint (use the control endpoint `/oauth/revoke` instead).
+- RFC 8628 Device Authorization Grant.
+- Multi-tenant / multi-user isolation.
+
+## Configuration
+
+OAuth is disabled by default. Add an `oauth` block to your `mock-llm.yaml` (or `POST`/`PATCH /config`) to enable it:
+
+```yaml
+oauth:
+  # Regex-matched request paths that require a valid Bearer.
+  protectedPaths:
+    - /mcp
+
+  # Pre-registered clients (DCR-registered clients are stored in-memory and
+  # survive until /oauth/reset).
+  clients:
+    - clientId: fixture-client
+      clientSecret: fixture-secret   # omit for public (PKCE) clients
+      redirectUris: ["http://127.0.0.1:39999/callback"]
+      scope: "mcp:read mcp:tools"
+
+  tokens:
+    expiresInSeconds: 3600             # default: 3600
+    refreshable: true                  # default: true
+    rotateRefreshToken: false          # default: false
+    revoked: []                        # access_tokens force-rejected
+    expired: []                        # access_tokens force-expired
+
+    # Optional deterministic token issuance. Each queue is consumed in order;
+    # once empty, values fall back to crypto-random hex. Let tests assert
+    # exact token strings.
+    deterministic:
+      nextAccessTokens: ["fixture-access-001"]
+      nextRefreshTokens: ["fixture-refresh-001"]
+      nextAuthorizationCodes: ["fixture-code-001"]
+      nextClientIds: ["fixture-client-001"]
+      nextClientSecrets: ["fixture-secret-001"]
+
+  metadata:
+    resourceName: "Mock MCP Resource"        # default
+    scopesSupported: ["mcp:read", "mcp:tools"]
+    registrationEndpointEnabled: true        # default — set false to hide /register
+    issuerOverride: "http://localhost:6556/" # default computed from host + port
+    resourcePath: "/mcp"                     # default
+```
+
+Only `issuerOverride` and `resourcePath` are read at server boot; everything else is evaluated per request so you can flip state mid-test via `PATCH /config`.
+
+## Test control endpoints
+
+These exist only in the fixture — real IdPs do not expose them:
+
+| Endpoint | Body | Behaviour |
+|---|---|---|
+| `POST /oauth/reset` | — | Wipes issued tokens, dynamic clients, and deterministic counters. Seeded `clients` survive. |
+| `POST /oauth/revoke` | `{"token": "..."}` or `{"refresh_token": "..."}` | Invalidates the token pair. Next request gated by the Bearer middleware gets a `401 invalid_token`. |
+| `POST /oauth/expire` | `{"token": "..."}` | Forces the token's `expiresAt` into the past. Controllers should transition to `Expired` on the next reconcile. |
+| `POST /oauth/issue` | `{"clientId": "...", "scope"?: "..."}` | Mints a Bearer without running the full flow. Use for stage-1 `MCPServer` fixtures where you pre-populate a Secret. |
+
+## End-to-end flow
+
+See the three executable samples for the canonical shape:
+
+- [`samples/14-mcp-oauth-discovery.sh`](../samples/14-mcp-oauth-discovery.sh) — 401 challenge + both discovery documents.
+- [`samples/15-mcp-oauth-pkce-flow.sh`](../samples/15-mcp-oauth-pkce-flow.sh) — DCR → PKCE → token exchange → authenticated `initialize`.
+- [`samples/16-mcp-oauth-refresh.sh`](../samples/16-mcp-oauth-refresh.sh) — `/oauth/issue` → refresh grant → `/oauth/revoke` → `/oauth/expire`.
+
+## Notes and gotchas
+
+- **Issuer URL is fixed at server boot.** Changing `metadata.issuerOverride` via `PATCH /config` has no effect — restart the process or start with the desired config.
+- **Protected resource metadata is served at the path-suffixed URL** (RFC 9728 §3.2), e.g. `/.well-known/oauth-protected-resource/mcp`, not at the root.
+- **Issuer href includes a trailing slash.** `URL.href` always normalises to one (`http://localhost:6556/`). Assertions comparing exact strings should strip or account for it.
+- **Redirect URIs must match exactly** — there is no glob support in the SDK's authorize handler. Register the exact loopback URI you plan to use.
+- **PKCE S256 is required.** `plain` is rejected at discovery time (we only advertise `S256`).
+- **Rate limits are disabled** in the fixture so CI can't flake on burst.

--- a/samples/14-mcp-oauth-discovery.sh
+++ b/samples/14-mcp-oauth-discovery.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Ensure 'mock-llm' is running first, e.g:
+# npm install -g @dwmkerr/mock-llm
+# mock-llm
+
+# Test OAuth discovery: 401 challenge on protected MCP path and both
+# RFC 9728 / RFC 8414 well-known metadata documents.
+
+BASE="http://localhost:6556"
+
+# Step 1: Enable Bearer gate on /mcp. Discovery endpoints and issuer metadata
+# are mounted at boot, so only protectedPaths needs toggling here.
+echo "Enabling OAuth gate on /mcp..."
+curl -fsSL -X PATCH "$BASE/config" \
+  -H "Content-Type: application/json" \
+  -d '{"oauth": {"protectedPaths": ["/mcp"]}}' > /dev/null
+
+# Step 2: Unauthenticated MCP initialize must return 401 with RFC 9728 challenge
+echo "Probing /mcp without Bearer..."
+status=$(curl -s -o /tmp/mcp-oauth-body.txt -D /tmp/mcp-oauth-head.txt \
+  -w "%{http_code}" -X POST "$BASE/mcp/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"1.0.0"}},"id":1}')
+
+if [ "$status" != "401" ]; then
+  echo "failed: expected 401, got $status"
+  exit 1
+fi
+echo "Got 401 as expected"
+
+www_auth=$(grep -i "^www-authenticate:" /tmp/mcp-oauth-head.txt | tr -d '\r')
+echo "$www_auth" | grep -q 'Bearer error="invalid_token"' || { echo "failed: missing invalid_token error"; exit 1; }
+echo "$www_auth" | grep -q 'resource_metadata=' || { echo "failed: missing resource_metadata"; exit 1; }
+echo "WWW-Authenticate OK: $www_auth"
+
+# Step 3: RFC 9728 protected resource metadata (served at resource-path-suffixed URL per RFC 9728 §3.2)
+echo "Fetching /.well-known/oauth-protected-resource/mcp..."
+pr_meta=$(curl -fsSL "$BASE/.well-known/oauth-protected-resource/mcp")
+
+resource=$(echo "$pr_meta" | jq -r '.resource')
+resource_name=$(echo "$pr_meta" | jq -r '.resource_name')
+auth_server=$(echo "$pr_meta" | jq -r '.authorization_servers[0]')
+
+# Strip trailing slashes on issuer-style URLs (URL.href normalises to include one).
+[ "${resource%/}" = "http://localhost:6556/mcp" ] || { echo "failed: resource=$resource"; exit 1; }
+[ "$resource_name" = "Mock MCP Resource" ] || { echo "failed: resource_name=$resource_name"; exit 1; }
+[ "${auth_server%/}" = "http://localhost:6556" ] || { echo "failed: auth_server=$auth_server"; exit 1; }
+echo "RFC 9728 document OK"
+
+# Step 4: RFC 8414 authorization server metadata
+echo "Fetching /.well-known/oauth-authorization-server..."
+as_meta=$(curl -fsSL "$BASE/.well-known/oauth-authorization-server")
+
+issuer=$(echo "$as_meta" | jq -r '.issuer')
+auth_ep=$(echo "$as_meta" | jq -r '.authorization_endpoint')
+token_ep=$(echo "$as_meta" | jq -r '.token_endpoint')
+reg_ep=$(echo "$as_meta" | jq -r '.registration_endpoint')
+pkce=$(echo "$as_meta" | jq -r '.code_challenge_methods_supported | index("S256")')
+grants=$(echo "$as_meta" | jq -r '.grant_types_supported | sort | join(",")')
+
+[ "${issuer%/}" = "http://localhost:6556" ] || { echo "failed: issuer=$issuer"; exit 1; }
+[ "$auth_ep" = "http://localhost:6556/authorize" ] || { echo "failed: auth_ep=$auth_ep"; exit 1; }
+[ "$token_ep" = "http://localhost:6556/token" ] || { echo "failed: token_ep=$token_ep"; exit 1; }
+[ "$reg_ep" = "http://localhost:6556/register" ] || { echo "failed: reg_ep=$reg_ep"; exit 1; }
+[ "$pkce" != "null" ] || { echo "failed: S256 not advertised"; exit 1; }
+[ "$grants" = "authorization_code,refresh_token" ] || { echo "failed: grants=$grants"; exit 1; }
+echo "RFC 8414 document OK"
+
+rm -f /tmp/mcp-oauth-body.txt /tmp/mcp-oauth-head.txt
+
+echo "passed"

--- a/samples/15-mcp-oauth-pkce-flow.sh
+++ b/samples/15-mcp-oauth-pkce-flow.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Ensure 'mock-llm' is running first, e.g:
+# npm install -g @dwmkerr/mock-llm
+# mock-llm
+
+# Full OAuth 2.1 Authorization Code + PKCE flow:
+# DCR -> authorize -> token exchange -> authenticated MCP initialize.
+# Uses deterministic fixture values so assertions compare exact strings.
+
+BASE="http://localhost:6556"
+REDIRECT="http://127.0.0.1:39999/callback"
+
+# Step 1: Configure OAuth with deterministic tokens / codes / clients.
+# Reset any state left by a prior sample so deterministic queues start at index 0.
+echo "Configuring OAuth fixture..."
+curl -fsSL -X POST "$BASE/oauth/reset" > /dev/null 2>&1 || true
+curl -fsSL -X PATCH "$BASE/config" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "oauth": {
+      "protectedPaths": ["/mcp"],
+      "tokens": {
+        "expiresInSeconds": 3600,
+        "refreshable": true,
+        "deterministic": {
+          "nextAccessTokens": ["fixture-access-001"],
+          "nextRefreshTokens": ["fixture-refresh-001"],
+          "nextAuthorizationCodes": ["fixture-code-001"],
+          "nextClientIds": ["fixture-client-001"],
+          "nextClientSecrets": ["fixture-secret-001"]
+        }
+      },
+      "metadata": {
+        "registrationEndpointEnabled": true,
+        "scopesSupported": ["mcp:read", "mcp:tools"]
+      }
+    }
+  }' > /dev/null
+
+# Step 2: Dynamic Client Registration (RFC 7591)
+echo "Registering client via DCR..."
+reg=$(curl -fsSL -X POST "$BASE/register" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"client_name\": \"ark-cli\",
+    \"redirect_uris\": [\"$REDIRECT\"],
+    \"grant_types\": [\"authorization_code\", \"refresh_token\"],
+    \"response_types\": [\"code\"],
+    \"token_endpoint_auth_method\": \"none\",
+    \"scope\": \"mcp:read mcp:tools\"
+  }")
+
+client_id=$(echo "$reg" | jq -r '.client_id')
+[ "$client_id" = "fixture-client-001" ] || { echo "failed: client_id=$client_id"; exit 1; }
+echo "client_id=$client_id"
+
+# Step 3: Generate PKCE verifier + S256 challenge
+echo "Generating PKCE pair..."
+code_verifier=$(openssl rand 32 | openssl base64 | tr '+/' '-_' | tr -d '=\n')
+code_challenge=$(printf '%s' "$code_verifier" \
+  | openssl dgst -sha256 -binary \
+  | openssl base64 | tr '+/' '-_' | tr -d '=\n')
+state="state-$RANDOM"
+
+# Step 4: Authorization endpoint - expect 302 with code+state on redirect_uri
+echo "Calling /authorize..."
+authorize_url="$BASE/authorize?response_type=code&client_id=$client_id&redirect_uri=$(printf %s "$REDIRECT" | jq -sRr @uri)&scope=mcp%3Aread&state=$state&code_challenge=$code_challenge&code_challenge_method=S256"
+
+location=$(curl -s -o /dev/null -w "%{redirect_url}" "$authorize_url")
+[ -n "$location" ] || { echo "failed: no Location header"; exit 1; }
+
+# Extract code + state from redirect query
+code=$(printf '%s' "$location" | sed -n 's/.*[?&]code=\([^&]*\).*/\1/p')
+returned_state=$(printf '%s' "$location" | sed -n 's/.*[?&]state=\([^&]*\).*/\1/p')
+
+[ "$code" = "fixture-code-001" ] || { echo "failed: code=$code"; exit 1; }
+[ "$returned_state" = "$state" ] || { echo "failed: state mismatch"; exit 1; }
+echo "Got code=$code state=$returned_state"
+
+# Step 5: Token endpoint - exchange code + verifier for tokens
+echo "Exchanging code for tokens..."
+tokens=$(curl -fsSL -X POST "$BASE/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$code" \
+  --data-urlencode "redirect_uri=$REDIRECT" \
+  --data-urlencode "client_id=$client_id" \
+  --data-urlencode "code_verifier=$code_verifier")
+
+access_token=$(echo "$tokens" | jq -r '.access_token')
+refresh_token=$(echo "$tokens" | jq -r '.refresh_token')
+token_type=$(echo "$tokens" | jq -r '.token_type')
+expires_in=$(echo "$tokens" | jq -r '.expires_in')
+
+[ "$access_token" = "fixture-access-001" ] || { echo "failed: access_token=$access_token"; exit 1; }
+[ "$refresh_token" = "fixture-refresh-001" ] || { echo "failed: refresh_token=$refresh_token"; exit 1; }
+[ "$token_type" = "Bearer" ] || { echo "failed: token_type=$token_type"; exit 1; }
+[ "$expires_in" = "3600" ] || { echo "failed: expires_in=$expires_in"; exit 1; }
+echo "Tokens OK: access=$access_token refresh=$refresh_token"
+
+# Step 6: Negative - reused code must fail
+echo "Verifying code cannot be replayed..."
+replay_status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$code" \
+  --data-urlencode "redirect_uri=$REDIRECT" \
+  --data-urlencode "client_id=$client_id" \
+  --data-urlencode "code_verifier=$code_verifier")
+[ "$replay_status" = "400" ] || { echo "failed: replay expected 400, got $replay_status"; exit 1; }
+echo "Code replay rejected (400)"
+
+# Step 7: Authenticated MCP initialize - must succeed
+echo "Initializing MCP with Bearer token..."
+init_response=$(curl -fsSL -N -X POST "$BASE/mcp/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $access_token" \
+  -D /tmp/mcp-oauth-init.txt \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}},"id":1}' \
+  | grep "^data: " | head -1 | sed 's/^data: //')
+
+protocol=$(echo "$init_response" | jq -r '.result.protocolVersion')
+[ -n "$protocol" ] && [ "$protocol" != "null" ] || { echo "failed: no protocolVersion in init response"; exit 1; }
+echo "MCP initialize OK (protocolVersion=$protocol)"
+
+session_id=$(grep -i "mcp-session-id:" /tmp/mcp-oauth-init.txt | cut -d' ' -f2 | tr -d '\r')
+curl -fsSL -X DELETE "$BASE/mcp/" \
+  -H "Authorization: Bearer $access_token" \
+  -H "mcp-session-id: $session_id" > /dev/null
+
+rm -f /tmp/mcp-oauth-init.txt
+
+echo "passed"

--- a/samples/16-mcp-oauth-refresh.sh
+++ b/samples/16-mcp-oauth-refresh.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Ensure 'mock-llm' is running first, e.g:
+# npm install -g @dwmkerr/mock-llm
+# mock-llm
+
+# Exercise refresh + revocation paths:
+#   1. Issue short-lived token directly via /oauth/issue control endpoint.
+#   2. Refresh it, confirm new access_token returned.
+#   3. Revoke it, confirm next MCP call sees 401.
+
+BASE="http://localhost:6556"
+
+# Step 1: Configure OAuth with short-lived deterministic tokens.
+# Reset any state left by a prior sample so deterministic queues start at index 0.
+echo "Configuring OAuth fixture with 5s token lifetime..."
+curl -fsSL -X POST "$BASE/oauth/reset" > /dev/null 2>&1 || true
+curl -fsSL -X PATCH "$BASE/config" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "oauth": {
+      "protectedPaths": ["/mcp"],
+      "clients": [{
+        "clientId": "refresh-client",
+        "redirectUris": ["http://127.0.0.1:*"]
+      }],
+      "tokens": {
+        "expiresInSeconds": 5,
+        "refreshable": true,
+        "rotateRefreshToken": true,
+        "deterministic": {
+          "nextAccessTokens": ["access-initial", "access-refreshed"],
+          "nextRefreshTokens": ["refresh-initial", "refresh-rotated"]
+        }
+      },
+      "metadata": {}
+    }
+  }' > /dev/null
+
+# Step 2: Issue token directly (simulates stage-1 manual-token test)
+echo "Issuing initial token..."
+issued=$(curl -fsSL -X POST "$BASE/oauth/issue" \
+  -H "Content-Type: application/json" \
+  -d '{"clientId":"refresh-client","scope":"mcp:read"}')
+
+access=$(echo "$issued" | jq -r '.access_token')
+refresh=$(echo "$issued" | jq -r '.refresh_token')
+expires_in=$(echo "$issued" | jq -r '.expires_in')
+
+[ "$access" = "access-initial" ] || { echo "failed: access=$access"; exit 1; }
+[ "$refresh" = "refresh-initial" ] || { echo "failed: refresh=$refresh"; exit 1; }
+[ "$expires_in" = "5" ] || { echo "failed: expires_in=$expires_in"; exit 1; }
+echo "Issued access=$access refresh=$refresh expires_in=${expires_in}s"
+
+# Step 3: Confirm token authorizes MCP
+echo "Verifying token authorizes /mcp..."
+status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/mcp/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $access" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"c","version":"1"}},"id":1}')
+[ "$status" = "200" ] || { echo "failed: initial token got $status"; exit 1; }
+echo "Initial token OK (200)"
+
+# Step 4: Refresh the access token
+echo "Refreshing token..."
+refreshed=$(curl -fsSL -X POST "$BASE/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=refresh_token" \
+  --data-urlencode "refresh_token=$refresh" \
+  --data-urlencode "client_id=refresh-client")
+
+new_access=$(echo "$refreshed" | jq -r '.access_token')
+new_refresh=$(echo "$refreshed" | jq -r '.refresh_token')
+
+[ "$new_access" = "access-refreshed" ] || { echo "failed: new_access=$new_access"; exit 1; }
+[ "$new_refresh" = "refresh-rotated" ] || { echo "failed: new_refresh=$new_refresh"; exit 1; }
+echo "Refreshed access=$new_access refresh=$new_refresh"
+
+# Step 5: Old refresh_token must now be invalid (rotateRefreshToken=true)
+echo "Verifying rotated refresh token is invalid..."
+old_refresh_status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=refresh_token" \
+  --data-urlencode "refresh_token=$refresh" \
+  --data-urlencode "client_id=refresh-client")
+[ "$old_refresh_status" = "400" ] || { echo "failed: old refresh expected 400, got $old_refresh_status"; exit 1; }
+echo "Rotated refresh rejected (400)"
+
+# Step 6: New access token authorizes MCP
+echo "Verifying new access token authorizes /mcp..."
+status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/mcp/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $new_access" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"c","version":"1"}},"id":1}')
+[ "$status" = "200" ] || { echo "failed: refreshed token got $status"; exit 1; }
+echo "Refreshed token OK (200)"
+
+# Step 7: Revoke via control endpoint, confirm 401 + WWW-Authenticate challenge
+echo "Revoking refreshed token..."
+curl -fsSL -X POST "$BASE/oauth/revoke" \
+  -H "Content-Type: application/json" \
+  -d "{\"token\":\"$new_access\"}" > /dev/null
+
+revoked_status=$(curl -s -o /dev/null -D /tmp/mcp-revoked-head.txt -w "%{http_code}" \
+  -X POST "$BASE/mcp/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $new_access" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"c","version":"1"}},"id":1}')
+[ "$revoked_status" = "401" ] || { echo "failed: revoked token expected 401, got $revoked_status"; exit 1; }
+
+www_auth=$(grep -i "^www-authenticate:" /tmp/mcp-revoked-head.txt | tr -d '\r')
+echo "$www_auth" | grep -q 'error="invalid_token"' || { echo "failed: missing invalid_token error: $www_auth"; exit 1; }
+echo "Revoked token rejected (401 invalid_token)"
+
+# Step 8: Force-expire path via /oauth/expire
+echo "Verifying /oauth/expire control endpoint..."
+issued2=$(curl -fsSL -X POST "$BASE/oauth/issue" \
+  -H "Content-Type: application/json" \
+  -d '{"clientId":"refresh-client"}')
+access2=$(echo "$issued2" | jq -r '.access_token')
+
+curl -fsSL -X POST "$BASE/oauth/expire" \
+  -H "Content-Type: application/json" \
+  -d "{\"token\":\"$access2\"}" > /dev/null
+
+expired_status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/mcp/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $access2" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"c","version":"1"}},"id":1}')
+[ "$expired_status" = "401" ] || { echo "failed: expired token expected 401, got $expired_status"; exit 1; }
+echo "Force-expired token rejected (401)"
+
+rm -f /tmp/mcp-revoked-head.txt
+
+echo "passed"

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,10 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 
+import { OAuthConfig } from './oauth/types';
+
+export { OAuthConfig } from './oauth/types';
+
 export interface Response {
   status: number;
   content: string;
@@ -23,6 +27,7 @@ export interface StreamingConfig {
 export interface Config {
   streaming: StreamingConfig;
   rules: Rule[];
+  oauth?: OAuthConfig;
 }
 
 export function getDefaultConfig(): Config {

--- a/src/oauth/clients-store.spec.ts
+++ b/src/oauth/clients-store.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from '@jest/globals';
+import { OAuthStore } from './store';
+import { createClientsStore } from './clients-store';
+import { OAuthConfig } from './types';
+
+describe('clientsStore', () => {
+  const clock = () => 1_700_000_000_000;
+  const config: OAuthConfig = {
+    protectedPaths: ['/mcp'],
+    clients: [{ clientId: 'seed', redirectUris: ['http://x'] }]
+  };
+
+  it('getClient returns seeded client', async () => {
+    const store = new OAuthStore(clock);
+    const cs = createClientsStore(store, () => config);
+    const c = await cs.getClient('seed');
+    expect(c?.client_id).toBe('seed');
+  });
+
+  it('getClient returns undefined when oauth config missing', async () => {
+    const store = new OAuthStore(clock);
+    const cs = createClientsStore(store, () => undefined);
+    expect(await cs.getClient('seed')).toBeUndefined();
+  });
+
+  it('getClient returns undefined for unknown id', async () => {
+    const store = new OAuthStore(clock);
+    const cs = createClientsStore(store, () => config);
+    expect(await cs.getClient('unknown')).toBeUndefined();
+  });
+
+  it('registerClient throws when oauth config missing', () => {
+    const store = new OAuthStore(clock);
+    const cs = createClientsStore(store, () => undefined);
+    expect(() => cs.registerClient!({
+      redirect_uris: ['http://x'], token_endpoint_auth_method: 'none'
+    })).toThrow(/not configured/);
+  });
+
+  it('registerClient persists a dynamically registered client', async () => {
+    const store = new OAuthStore(clock);
+    const cs = createClientsStore(store, () => config);
+    const registered = await cs.registerClient!({
+      redirect_uris: ['http://127.0.0.1:39999/callback'],
+      token_endpoint_auth_method: 'none'
+    });
+    const fetched = await cs.getClient(registered.client_id);
+    expect(fetched?.client_id).toBe(registered.client_id);
+  });
+});

--- a/src/oauth/clients-store.ts
+++ b/src/oauth/clients-store.ts
@@ -1,0 +1,27 @@
+import type { Response } from 'express';
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import { OAuthStore } from './store';
+import { OAuthConfig } from './types';
+
+export function createClientsStore(
+  store: OAuthStore,
+  getConfig: () => OAuthConfig | undefined
+): OAuthRegisteredClientsStore {
+  return {
+    getClient(clientId: string): OAuthClientInformationFull | undefined {
+      const config = getConfig();
+      if (!config) return undefined;
+      return store.getClient(config, clientId);
+    },
+    registerClient(input): OAuthClientInformationFull {
+      const config = getConfig();
+      if (!config) {
+        throw new Error('OAuth not configured');
+      }
+      return store.registerClient(config, input);
+    }
+  };
+}
+
+export { Response };

--- a/src/oauth/control.spec.ts
+++ b/src/oauth/control.spec.ts
@@ -94,6 +94,31 @@ describe('control endpoints', () => {
       expect(res.status).toBe(204);
       expect(store.isValid(config, issued.accessToken)).toBe(false);
     });
+
+    it('rejects missing token field with 400', async () => {
+      const res = await fetch(`${base}/oauth/expire`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}'
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /oauth/issue (config gating)', () => {
+    it('returns 409 when oauth config is missing', async () => {
+      const miniApp = express();
+      miniApp.use('/oauth', createControlRouter(store, () => undefined));
+      const miniServer = miniApp.listen(0);
+      const { port } = miniServer.address() as { port: number };
+      const res = await fetch(`http://localhost:${port}/oauth/issue`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientId: 'cx' })
+      });
+      expect(res.status).toBe(409);
+      miniServer.close();
+    });
   });
 
   describe('POST /oauth/reset', () => {

--- a/src/oauth/control.spec.ts
+++ b/src/oauth/control.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import express from 'express';
+import { OAuthStore } from './store';
+import { createControlRouter } from './control';
+import { OAuthConfig } from './types';
+
+describe('control endpoints', () => {
+  const now = 1_700_000_000_000;
+  const clock = () => now;
+  const store = new OAuthStore(clock);
+  const config: OAuthConfig = { protectedPaths: ['/mcp'], tokens: { expiresInSeconds: 100, refreshable: true } };
+
+  const app = express();
+  app.use('/oauth', createControlRouter(store, () => config));
+  let server: ReturnType<typeof app.listen>;
+  let base: string;
+
+  beforeAll((done) => {
+    server = app.listen(0, () => {
+      const addr = server.address() as { port: number };
+      base = `http://localhost:${addr.port}`;
+      done();
+    });
+  });
+  afterAll((done) => { server.close(done); });
+
+  describe('POST /oauth/issue', () => {
+    it('mints a usable token for a given clientId', async () => {
+      const res = await fetch(`${base}/oauth/issue`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientId: 'cx', scope: 'mcp:read' })
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { access_token: string; token_type: string; expires_in: number; scope: string };
+      expect(body.access_token).toBeDefined();
+      expect(body.token_type).toBe('Bearer');
+      expect(body.expires_in).toBe(100);
+      expect(body.scope).toBe('mcp:read');
+      expect(store.isValid(config, body.access_token)).toBe(true);
+    });
+
+    it('rejects missing clientId', async () => {
+      const res = await fetch(`${base}/oauth/issue`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /oauth/revoke', () => {
+    it('invalidates issued token', async () => {
+      const issued = store.issueToken(config, 'cx', ['s']);
+      const res = await fetch(`${base}/oauth/revoke`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: issued.accessToken })
+      });
+      expect(res.status).toBe(204);
+      expect(store.isValid(config, issued.accessToken)).toBe(false);
+    });
+
+    it('accepts refresh_token field as alternative', async () => {
+      const issued = store.issueToken(config, 'cx', ['s']);
+      const res = await fetch(`${base}/oauth/revoke`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: issued.refreshToken })
+      });
+      expect(res.status).toBe(204);
+      expect(store.isValid(config, issued.accessToken)).toBe(false);
+    });
+
+    it('rejects empty body', async () => {
+      const res = await fetch(`${base}/oauth/revoke`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}'
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /oauth/expire', () => {
+    it('forces a valid token to become invalid', async () => {
+      const issued = store.issueToken(config, 'cx', ['s']);
+      const res = await fetch(`${base}/oauth/expire`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: issued.accessToken })
+      });
+      expect(res.status).toBe(204);
+      expect(store.isValid(config, issued.accessToken)).toBe(false);
+    });
+  });
+
+  describe('POST /oauth/reset', () => {
+    it('wipes all issued tokens', async () => {
+      const issued = store.issueToken(config, 'cx', ['s']);
+      const res = await fetch(`${base}/oauth/reset`, { method: 'POST' });
+      expect(res.status).toBe(204);
+      expect(store.isValid(config, issued.accessToken)).toBe(false);
+    });
+  });
+});

--- a/src/oauth/control.ts
+++ b/src/oauth/control.ts
@@ -1,0 +1,62 @@
+import express, { Request, Response } from 'express';
+import { OAuthStore } from './store';
+import { OAuthConfig } from './types';
+
+export function createControlRouter(
+  store: OAuthStore,
+  getConfig: () => OAuthConfig | undefined
+): express.Router {
+  const router = express.Router();
+  router.use(express.json());
+
+  router.post('/revoke', (req: Request, res: Response) => {
+    const token = typeof req.body?.token === 'string' ? req.body.token : undefined;
+    const refreshToken = typeof req.body?.refresh_token === 'string' ? req.body.refresh_token : undefined;
+    const target = token ?? refreshToken;
+    if (!target) {
+      res.status(400).json({ error: 'token or refresh_token required' });
+      return;
+    }
+    store.revoke(target);
+    res.status(204).send();
+  });
+
+  router.post('/expire', (req: Request, res: Response) => {
+    const token = typeof req.body?.token === 'string' ? req.body.token : undefined;
+    if (!token) {
+      res.status(400).json({ error: 'token required' });
+      return;
+    }
+    store.forceExpire(token);
+    res.status(204).send();
+  });
+
+  router.post('/reset', (_req: Request, res: Response) => {
+    store.reset();
+    res.status(204).send();
+  });
+
+  router.post('/issue', (req: Request, res: Response) => {
+    const config = getConfig();
+    if (!config) {
+      res.status(409).json({ error: 'oauth not configured' });
+      return;
+    }
+    const clientId = typeof req.body?.clientId === 'string' ? req.body.clientId : undefined;
+    if (!clientId) {
+      res.status(400).json({ error: 'clientId required' });
+      return;
+    }
+    const scopes = typeof req.body?.scope === 'string' ? req.body.scope.split(' ').filter(Boolean) : [];
+    const issued = store.issueToken(config, clientId, scopes);
+    res.status(200).json({
+      access_token: issued.accessToken,
+      token_type: 'Bearer',
+      expires_in: Math.max(0, Math.floor((issued.expiresAt - issued.issuedAt) / 1000)),
+      refresh_token: issued.refreshToken,
+      scope: scopes.join(' ') || undefined
+    });
+  });
+
+  return router;
+}

--- a/src/oauth/index.spec.ts
+++ b/src/oauth/index.spec.ts
@@ -225,6 +225,29 @@ describe('oauth end-to-end', () => {
     });
   });
 
+  describe('setup options', () => {
+    it('honours metadata.issuerOverride and survives bad regex in protectedPaths', async () => {
+      const cfg: Config = withOAuth({
+        protectedPaths: ['/mcp', '[invalid(regex'],
+        metadata: { issuerOverride: 'http://127.0.0.1:6556/' }
+      });
+      const altApp = createServer(cfg, 'localhost', 6556);
+      const altServer = altApp.listen(0);
+      const { port } = altServer.address() as { port: number };
+      try {
+        const meta = await fetch(`http://localhost:${port}/.well-known/oauth-authorization-server`)
+          .then(r => r.json() as Promise<Record<string, unknown>>);
+        expect(meta.issuer).toBe('http://127.0.0.1:6556/');
+
+        // Request an unprotected, unmatched path — the bad-regex entry must not throw.
+        const unprotected = await fetch(`http://localhost:${port}/health`);
+        expect(unprotected.status).toBe(200);
+      } finally {
+        altServer.close();
+      }
+    });
+  });
+
   describe('refresh grant', () => {
     it('refresh issues a new access token and keeps original refresh_token when rotation is off', async () => {
       const cfg: Config = withOAuth({

--- a/src/oauth/index.spec.ts
+++ b/src/oauth/index.spec.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { createHash } from 'node:crypto';
+import { createServer } from '../server';
+import { Config, getDefaultConfig } from '../config';
+
+const PROBE_INIT = JSON.stringify({
+  jsonrpc: '2.0',
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'probe', version: '1.0.0' }
+  },
+  id: 1
+});
+
+function base64url(buf: Buffer): string {
+  return buf.toString('base64url');
+}
+
+function withOAuth(patch: Partial<Config['oauth']>): Config {
+  const cfg = getDefaultConfig() as Config;
+  cfg.oauth = { protectedPaths: [], ...patch } as Config['oauth'];
+  return cfg;
+}
+
+describe('oauth end-to-end', () => {
+  const app = createServer(withOAuth({
+    protectedPaths: ['/mcp'],
+    tokens: {
+      expiresInSeconds: 3600,
+      refreshable: true,
+      deterministic: {
+        nextAccessTokens: ['fixture-access-001'],
+        nextRefreshTokens: ['fixture-refresh-001'],
+        nextAuthorizationCodes: ['fixture-code-001'],
+        nextClientIds: ['fixture-client-001']
+      }
+    }
+  }), 'localhost', 6556);
+  let server: ReturnType<typeof app.listen>;
+  let base: string;
+
+  beforeAll((done) => {
+    server = app.listen(0, () => {
+      const addr = server.address() as { port: number };
+      base = `http://localhost:${addr.port}`;
+      done();
+    });
+  });
+  afterAll((done) => { server.close(done); });
+
+  describe('discovery', () => {
+    it('serves RFC 8414 authorization server metadata', async () => {
+      const res = await fetch(`${base}/.well-known/oauth-authorization-server`);
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.issuer).toBeDefined();
+      expect(body.authorization_endpoint).toMatch(/\/authorize$/);
+      expect(body.token_endpoint).toMatch(/\/token$/);
+      expect(body.registration_endpoint).toMatch(/\/register$/);
+      expect(body.code_challenge_methods_supported).toEqual(['S256']);
+      expect(body.grant_types_supported).toEqual(['authorization_code', 'refresh_token']);
+    });
+
+    it('serves RFC 9728 protected resource metadata at the path-suffixed URL', async () => {
+      const res = await fetch(`${base}/.well-known/oauth-protected-resource/mcp`);
+      expect(res.status).toBe(200);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.resource).toMatch(/\/mcp$/);
+      expect(Array.isArray(body.authorization_servers)).toBe(true);
+      expect(body.resource_name).toBe('Mock MCP Resource');
+    });
+  });
+
+  describe('gate', () => {
+    it('returns 401 with RFC 9728 WWW-Authenticate when no Bearer token is sent', async () => {
+      const res = await fetch(`${base}/mcp/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json, text/event-stream' },
+        body: PROBE_INIT
+      });
+      expect(res.status).toBe(401);
+      const wwwAuth = res.headers.get('www-authenticate');
+      expect(wwwAuth).toContain('Bearer');
+      expect(wwwAuth).toContain('error="invalid_token"');
+      expect(wwwAuth).toContain('resource_metadata=');
+    });
+
+    it('returns 401 for a bogus Bearer token', async () => {
+      const res = await fetch(`${base}/mcp/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'Authorization': 'Bearer nonsense'
+        },
+        body: PROBE_INIT
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('end-to-end PKCE flow', () => {
+    it('DCR → authorize → token → authenticated MCP initialize', async () => {
+      const redirectUri = 'http://127.0.0.1:39999/callback';
+
+      // DCR
+      const dcr = await fetch(`${base}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          client_name: 'test',
+          redirect_uris: [redirectUri],
+          grant_types: ['authorization_code', 'refresh_token'],
+          response_types: ['code'],
+          token_endpoint_auth_method: 'none'
+        })
+      });
+      expect(dcr.status).toBe(201);
+      const client = await dcr.json() as { client_id: string };
+      expect(client.client_id).toBe('fixture-client-001');
+
+      // PKCE
+      const verifier = base64url(Buffer.from('test-verifier-abc123test-verifier-abc123'));
+      const challenge = base64url(createHash('sha256').update(verifier).digest());
+
+      // Authorize
+      const authUrl = new URL(`${base}/authorize`);
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('client_id', client.client_id);
+      authUrl.searchParams.set('redirect_uri', redirectUri);
+      authUrl.searchParams.set('state', 'state-xyz');
+      authUrl.searchParams.set('code_challenge', challenge);
+      authUrl.searchParams.set('code_challenge_method', 'S256');
+      const authRes = await fetch(authUrl.href, { redirect: 'manual' });
+      expect(authRes.status).toBe(302);
+      const location = authRes.headers.get('location')!;
+      const redirected = new URL(location);
+      expect(redirected.searchParams.get('code')).toBe('fixture-code-001');
+      expect(redirected.searchParams.get('state')).toBe('state-xyz');
+
+      // Token exchange
+      const tokenBody = new URLSearchParams();
+      tokenBody.set('grant_type', 'authorization_code');
+      tokenBody.set('code', 'fixture-code-001');
+      tokenBody.set('redirect_uri', redirectUri);
+      tokenBody.set('client_id', client.client_id);
+      tokenBody.set('code_verifier', verifier);
+      const tokenRes = await fetch(`${base}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: tokenBody.toString()
+      });
+      expect(tokenRes.status).toBe(200);
+      const tokens = await tokenRes.json() as { access_token: string; refresh_token: string; token_type: string; expires_in: number };
+      expect(tokens.access_token).toBe('fixture-access-001');
+      expect(tokens.refresh_token).toBe('fixture-refresh-001');
+      expect(tokens.token_type).toBe('Bearer');
+      expect(tokens.expires_in).toBe(3600);
+
+      // Replayed code is rejected
+      const replay = await fetch(`${base}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: tokenBody.toString()
+      });
+      expect(replay.status).toBe(400);
+
+      // Authenticated MCP initialize
+      const mcpRes = await fetch(`${base}/mcp/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+          'Authorization': `Bearer ${tokens.access_token}`
+        },
+        body: PROBE_INIT
+      });
+      expect(mcpRes.status).toBe(200);
+    });
+
+    it('rejects /token with a mismatched PKCE verifier', async () => {
+      const redirectUri = 'http://127.0.0.1:39998/callback';
+
+      const dcr = await fetch(`${base}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          client_name: 'bad',
+          redirect_uris: [redirectUri],
+          grant_types: ['authorization_code'],
+          response_types: ['code'],
+          token_endpoint_auth_method: 'none'
+        })
+      });
+      const client = await dcr.json() as { client_id: string };
+
+      const verifier = 'real-verifier-0000000000000000000000000000';
+      const challenge = base64url(createHash('sha256').update(verifier).digest());
+
+      const authUrl = new URL(`${base}/authorize`);
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('client_id', client.client_id);
+      authUrl.searchParams.set('redirect_uri', redirectUri);
+      authUrl.searchParams.set('code_challenge', challenge);
+      authUrl.searchParams.set('code_challenge_method', 'S256');
+      const authRes = await fetch(authUrl.href, { redirect: 'manual' });
+      const code = new URL(authRes.headers.get('location')!).searchParams.get('code')!;
+
+      const tokenBody = new URLSearchParams();
+      tokenBody.set('grant_type', 'authorization_code');
+      tokenBody.set('code', code);
+      tokenBody.set('redirect_uri', redirectUri);
+      tokenBody.set('client_id', client.client_id);
+      tokenBody.set('code_verifier', 'wrong-verifier-11111111111111111111111111');
+      const res = await fetch(`${base}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: tokenBody.toString()
+      });
+      expect(res.status).toBe(400);
+      const err = await res.json() as { error: string };
+      expect(err.error).toBe('invalid_grant');
+    });
+  });
+
+  describe('refresh grant', () => {
+    it('refresh issues a new access token and keeps original refresh_token when rotation is off', async () => {
+      const cfg: Config = withOAuth({
+        protectedPaths: ['/mcp'],
+        clients: [{ clientId: 'ref-client', redirectUris: ['http://x'] }],
+        tokens: {
+          expiresInSeconds: 60,
+          refreshable: true,
+          deterministic: {
+            nextAccessTokens: ['acc-a', 'acc-b'],
+            nextRefreshTokens: ['ref-a']
+          }
+        }
+      });
+      await fetch(`${base}/config`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cfg)
+      });
+      await fetch(`${base}/oauth/reset`, { method: 'POST' });
+
+      const issued = await fetch(`${base}/oauth/issue`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientId: 'ref-client' })
+      }).then(r => r.json() as Promise<{ access_token: string; refresh_token: string }>);
+
+      const body = new URLSearchParams();
+      body.set('grant_type', 'refresh_token');
+      body.set('refresh_token', issued.refresh_token);
+      body.set('client_id', 'ref-client');
+      const res = await fetch(`${base}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString()
+      });
+      expect(res.status).toBe(200);
+      const refreshed = await res.json() as { access_token: string; refresh_token: string };
+      expect(refreshed.access_token).toBe('acc-b');
+      expect(refreshed.refresh_token).toBe(issued.refresh_token);
+    });
+  });
+});

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1,0 +1,79 @@
+import express from 'express';
+import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
+import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
+import { Config } from '../config';
+import { OAuthStore } from './store';
+import { OAuthConfig } from './types';
+import { createClientsStore } from './clients-store';
+import { createProvider } from './provider';
+import { createControlRouter } from './control';
+
+export interface SetupOAuthOptions {
+  host: string;
+  port: number;
+  clock?: () => number;
+}
+
+function resolveIssuer(initialOAuth: OAuthConfig | undefined, host: string, port: number): URL {
+  if (initialOAuth?.metadata?.issuerOverride) {
+    return new URL(initialOAuth.metadata.issuerOverride);
+  }
+  const safeHost = host === '0.0.0.0' || host === '::' ? 'localhost' : host;
+  return new URL(`http://${safeHost}:${port}/`);
+}
+
+export function setupOAuth(
+  app: express.Express,
+  getConfig: () => Config,
+  options: SetupOAuthOptions
+): void {
+  const clock = options.clock ?? (() => Date.now());
+  const store = new OAuthStore(clock);
+  const oauthGetter = (): OAuthConfig | undefined => getConfig().oauth;
+
+  const clientsStore = createClientsStore(store, oauthGetter);
+  const provider = createProvider(store, clientsStore, oauthGetter);
+
+  const initialOAuth = getConfig().oauth;
+  const issuerUrl = resolveIssuer(initialOAuth, options.host, options.port);
+  const resourcePath = initialOAuth?.metadata?.resourcePath ?? '/mcp';
+  const resourceServerUrl = new URL(resourcePath, issuerUrl);
+  const scopesSupported = initialOAuth?.metadata?.scopesSupported ?? ['mcp:read', 'mcp:tools'];
+  const resourceName = initialOAuth?.metadata?.resourceName ?? 'Mock MCP Resource';
+  const resourceMetadataUrl = new URL(
+    `/.well-known/oauth-protected-resource${resourcePath === '/' ? '' : resourcePath}`,
+    issuerUrl
+  ).href;
+
+  // Mount SDK OAuth router (authorize, token, register, well-known). Rate limits disabled
+  // for deterministic testing.
+  app.use(mcpAuthRouter({
+    provider,
+    issuerUrl,
+    resourceServerUrl,
+    scopesSupported,
+    resourceName,
+    authorizationOptions: { rateLimit: false },
+    tokenOptions: { rateLimit: false },
+    clientRegistrationOptions: { rateLimit: false, clientIdGeneration: false }
+  }));
+
+  // Dynamic Bearer gate: only challenges when current config lists the path.
+  const gate = requireBearerAuth({ verifier: provider, resourceMetadataUrl });
+  app.use((req, res, next) => {
+    const oauth = oauthGetter();
+    if (!oauth || oauth.protectedPaths.length === 0) return next();
+    const matched = oauth.protectedPaths.some(p => {
+      try {
+        return new RegExp(p).test(req.path);
+      } catch {
+        return false;
+      }
+    });
+    if (!matched) return next();
+    return gate(req, res, next);
+  });
+
+  // Fixture control endpoints.
+  app.use('/oauth', createControlRouter(store, oauthGetter));
+}

--- a/src/oauth/provider.spec.ts
+++ b/src/oauth/provider.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import type { Response } from 'express';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import {
+  InvalidGrantError,
+  InvalidTokenError,
+  ServerError
+} from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import { OAuthStore } from './store';
+import { createClientsStore } from './clients-store';
+import { createProvider } from './provider';
+import { OAuthConfig } from './types';
+
+describe('OAuthServerProvider', () => {
+  const now = 1_700_000_000_000;
+  const clock = () => now;
+  let store: OAuthStore;
+  let config: OAuthConfig | undefined;
+  const getConfig = () => config;
+  const baseConfig: OAuthConfig = {
+    protectedPaths: ['/mcp'],
+    tokens: { expiresInSeconds: 100, refreshable: true }
+  };
+
+  const client = (clientId = 'c1'): OAuthClientInformationFull => ({
+    client_id: clientId,
+    redirect_uris: ['http://127.0.0.1:39999/callback'],
+    token_endpoint_auth_method: 'none'
+  });
+
+  const mockRes = (): { res: Response; redirect: jest.Mock } => {
+    const redirect = jest.fn();
+    return { res: { redirect } as unknown as Response, redirect };
+  };
+
+  beforeEach(() => {
+    store = new OAuthStore(clock);
+    config = baseConfig;
+  });
+
+  const provider = () => createProvider(store, createClientsStore(store, getConfig), getConfig);
+
+  describe('requireConfig', () => {
+    it('verifyAccessToken throws ServerError when oauth config is missing', async () => {
+      config = undefined;
+      await expect(provider().verifyAccessToken('any')).rejects.toBeInstanceOf(ServerError);
+    });
+  });
+
+  describe('authorize', () => {
+    it('issues a code and redirects with code+state', async () => {
+      const { res, redirect } = mockRes();
+      await provider().authorize(client(), {
+        state: 'S1',
+        scopes: ['mcp:read'],
+        redirectUri: 'http://127.0.0.1:39999/callback',
+        codeChallenge: 'cc'
+      }, res);
+      expect(redirect).toHaveBeenCalledTimes(1);
+      const [status, url] = redirect.mock.calls[0];
+      expect(status).toBe(302);
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get('code')).toMatch(/.+/);
+      expect(parsed.searchParams.get('state')).toBe('S1');
+    });
+
+    it('omits state when not provided', async () => {
+      const { res, redirect } = mockRes();
+      await provider().authorize(client(), {
+        scopes: [],
+        redirectUri: 'http://127.0.0.1:39999/callback',
+        codeChallenge: 'cc'
+      }, res);
+      const [, url] = redirect.mock.calls[0];
+      expect(new URL(url as string).searchParams.get('state')).toBeNull();
+    });
+  });
+
+  describe('challengeForAuthorizationCode', () => {
+    it('returns stored challenge', async () => {
+      const code = store.issueAuthCode(baseConfig, {
+        clientId: 'c1', redirectUri: 'http://x', codeChallenge: 'CC', scopes: []
+      });
+      await expect(provider().challengeForAuthorizationCode(client(), code.code)).resolves.toBe('CC');
+    });
+
+    it('throws InvalidGrantError for unknown code', async () => {
+      await expect(provider().challengeForAuthorizationCode(client(), 'nope'))
+        .rejects.toBeInstanceOf(InvalidGrantError);
+    });
+
+    it('throws InvalidGrantError when code was issued to a different client', async () => {
+      const code = store.issueAuthCode(baseConfig, {
+        clientId: 'other', redirectUri: 'http://x', codeChallenge: 'CC', scopes: []
+      });
+      await expect(provider().challengeForAuthorizationCode(client('c1'), code.code))
+        .rejects.toBeInstanceOf(InvalidGrantError);
+    });
+  });
+
+  describe('exchangeAuthorizationCode', () => {
+    it('issues tokens when code, client, and redirect_uri match', async () => {
+      const code = store.issueAuthCode(baseConfig, {
+        clientId: 'c1', redirectUri: 'http://127.0.0.1:39999/callback', codeChallenge: 'CC', scopes: ['mcp:read']
+      });
+      const tokens = await provider().exchangeAuthorizationCode(
+        client('c1'), code.code, undefined, 'http://127.0.0.1:39999/callback'
+      );
+      expect(tokens.access_token).toMatch(/.+/);
+      expect(tokens.scope).toBe('mcp:read');
+    });
+
+    it('rejects unknown or expired codes', async () => {
+      await expect(provider().exchangeAuthorizationCode(client(), 'nope', undefined, undefined))
+        .rejects.toBeInstanceOf(InvalidGrantError);
+    });
+
+    it('rejects code issued to a different client', async () => {
+      const code = store.issueAuthCode(baseConfig, {
+        clientId: 'other', redirectUri: 'http://x', codeChallenge: 'CC', scopes: []
+      });
+      await expect(provider().exchangeAuthorizationCode(client('c1'), code.code, undefined, undefined))
+        .rejects.toBeInstanceOf(InvalidGrantError);
+    });
+
+    it('rejects mismatched redirect_uri', async () => {
+      const code = store.issueAuthCode(baseConfig, {
+        clientId: 'c1', redirectUri: 'http://a/callback', codeChallenge: 'CC', scopes: []
+      });
+      await expect(provider().exchangeAuthorizationCode(
+        client('c1'), code.code, undefined, 'http://b/callback'
+      )).rejects.toBeInstanceOf(InvalidGrantError);
+    });
+  });
+
+  describe('exchangeRefreshToken', () => {
+    it('rejects when refreshable=false', async () => {
+      config = { ...baseConfig, tokens: { ...baseConfig.tokens, refreshable: false } };
+      await expect(provider().exchangeRefreshToken(client(), 'any'))
+        .rejects.toBeInstanceOf(InvalidGrantError);
+    });
+
+    it('rejects unknown refresh_token', async () => {
+      await expect(provider().exchangeRefreshToken(client(), 'nope'))
+        .rejects.toBeInstanceOf(InvalidGrantError);
+    });
+
+    it('rejects refresh_token issued to a different client', async () => {
+      const issued = store.issueToken(baseConfig, 'other', ['s']);
+      await expect(provider().exchangeRefreshToken(client('c1'), issued.refreshToken!))
+        .rejects.toBeInstanceOf(InvalidGrantError);
+    });
+
+    it('issues new access token on happy path', async () => {
+      const issued = store.issueToken(baseConfig, 'c1', ['s']);
+      const tokens = await provider().exchangeRefreshToken(client('c1'), issued.refreshToken!);
+      expect(tokens.access_token).not.toBe(issued.accessToken);
+    });
+  });
+
+  describe('verifyAccessToken', () => {
+    it('returns AuthInfo with expiresAt in seconds for a valid token', async () => {
+      const issued = store.issueToken(baseConfig, 'c1', ['mcp:read']);
+      const info = await provider().verifyAccessToken(issued.accessToken);
+      expect(info.token).toBe(issued.accessToken);
+      expect(info.clientId).toBe('c1');
+      expect(info.scopes).toEqual(['mcp:read']);
+      expect(info.expiresAt).toBe(Math.floor(issued.expiresAt / 1000));
+    });
+
+    it('throws InvalidTokenError for unknown token', async () => {
+      await expect(provider().verifyAccessToken('nope')).rejects.toBeInstanceOf(InvalidTokenError);
+    });
+  });
+});

--- a/src/oauth/provider.ts
+++ b/src/oauth/provider.ts
@@ -1,0 +1,125 @@
+import type { Response } from 'express';
+import type {
+  OAuthServerProvider,
+  AuthorizationParams
+} from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type { OAuthClientInformationFull, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import {
+  InvalidGrantError,
+  InvalidTokenError,
+  ServerError
+} from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import { OAuthStore } from './store';
+import { OAuthConfig } from './types';
+
+export function createProvider(
+  store: OAuthStore,
+  clientsStore: OAuthRegisteredClientsStore,
+  getConfig: () => OAuthConfig | undefined
+): OAuthServerProvider {
+  const requireConfig = (): OAuthConfig => {
+    const c = getConfig();
+    if (!c) {
+      throw new ServerError('OAuth not configured');
+    }
+    return c;
+  };
+
+  const toTokens = (t: { accessToken: string; refreshToken?: string; scopes: string[]; expiresAt: number; issuedAt: number }): OAuthTokens => ({
+    access_token: t.accessToken,
+    token_type: 'Bearer',
+    expires_in: Math.max(0, Math.floor((t.expiresAt - t.issuedAt) / 1000)),
+    refresh_token: t.refreshToken,
+    scope: t.scopes.join(' ') || undefined
+  });
+
+  return {
+    get clientsStore() { return clientsStore; },
+
+    async authorize(
+      client: OAuthClientInformationFull,
+      params: AuthorizationParams,
+      res: Response
+    ): Promise<void> {
+      const config = requireConfig();
+      const entry = store.issueAuthCode(config, {
+        clientId: client.client_id,
+        redirectUri: params.redirectUri,
+        codeChallenge: params.codeChallenge,
+        scopes: params.scopes ?? []
+      });
+      const redirect = new URL(params.redirectUri);
+      redirect.searchParams.set('code', entry.code);
+      if (params.state) {
+        redirect.searchParams.set('state', params.state);
+      }
+      res.redirect(302, redirect.href);
+    },
+
+    async challengeForAuthorizationCode(
+      client: OAuthClientInformationFull,
+      authorizationCode: string
+    ): Promise<string> {
+      const entry = store.getAuthCode(authorizationCode);
+      if (!entry || entry.clientId !== client.client_id) {
+        throw new InvalidGrantError('Unknown or mismatched authorization code');
+      }
+      return entry.codeChallenge;
+    },
+
+    async exchangeAuthorizationCode(
+      client: OAuthClientInformationFull,
+      authorizationCode: string,
+      _codeVerifier: string | undefined,
+      redirectUri: string | undefined
+    ): Promise<OAuthTokens> {
+      const config = requireConfig();
+      const entry = store.consumeAuthCode(authorizationCode);
+      if (!entry) {
+        throw new InvalidGrantError('Authorization code is invalid or expired');
+      }
+      if (entry.clientId !== client.client_id) {
+        throw new InvalidGrantError('Authorization code was issued to a different client');
+      }
+      if (redirectUri !== undefined && redirectUri !== entry.redirectUri) {
+        throw new InvalidGrantError('redirect_uri does not match the original request');
+      }
+      const issued = store.issueToken(config, client.client_id, entry.scopes);
+      return toTokens(issued);
+    },
+
+    async exchangeRefreshToken(
+      client: OAuthClientInformationFull,
+      refreshToken: string
+    ): Promise<OAuthTokens> {
+      const config = requireConfig();
+      if (config.tokens?.refreshable === false) {
+        throw new InvalidGrantError('Refresh tokens are disabled');
+      }
+      const issued = store.refreshToken(config, refreshToken);
+      if (!issued) {
+        throw new InvalidGrantError('Refresh token is invalid or expired');
+      }
+      if (issued.clientId !== client.client_id) {
+        throw new InvalidGrantError('Refresh token was issued to a different client');
+      }
+      return toTokens(issued);
+    },
+
+    async verifyAccessToken(token: string): Promise<AuthInfo> {
+      const config = requireConfig();
+      if (!store.isValid(config, token)) {
+        throw new InvalidTokenError('Token is invalid, revoked, or expired');
+      }
+      const stored = store.getToken(token)!;
+      return {
+        token,
+        clientId: stored.clientId,
+        scopes: stored.scopes,
+        expiresAt: Math.floor(stored.expiresAt / 1000)
+      };
+    }
+  };
+}

--- a/src/oauth/store.spec.ts
+++ b/src/oauth/store.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { OAuthStore } from './store';
+import { OAuthConfig } from './types';
+
+describe('OAuthStore', () => {
+  let now = 1_700_000_000_000;
+  const clock = () => now;
+  let store: OAuthStore;
+  const baseConfig: OAuthConfig = {
+    protectedPaths: ['/mcp'],
+    tokens: { expiresInSeconds: 100, refreshable: true }
+  };
+
+  beforeEach(() => {
+    now = 1_700_000_000_000;
+    store = new OAuthStore(clock);
+  });
+
+  describe('deterministic issuance', () => {
+    it('consumes deterministic access+refresh tokens in order, falls back to random', () => {
+      const config: OAuthConfig = {
+        ...baseConfig,
+        tokens: {
+          expiresInSeconds: 100, refreshable: true,
+          deterministic: { nextAccessTokens: ['a1', 'a2'], nextRefreshTokens: ['r1'] }
+        }
+      };
+      const t1 = store.issueToken(config, 'c', ['mcp:read']);
+      const t2 = store.issueToken(config, 'c', ['mcp:read']);
+      const t3 = store.issueToken(config, 'c', ['mcp:read']);
+      expect(t1.accessToken).toBe('a1');
+      expect(t1.refreshToken).toBe('r1');
+      expect(t2.accessToken).toBe('a2');
+      expect(t2.refreshToken).toMatch(/^[a-f0-9]{32}$/);
+      expect(t3.accessToken).toMatch(/^[a-f0-9]{32}$/);
+    });
+  });
+
+  describe('validation', () => {
+    it('valid for freshly issued token', () => {
+      const t = store.issueToken(baseConfig, 'c', ['s']);
+      expect(store.isValid(baseConfig, t.accessToken)).toBe(true);
+    });
+
+    it('invalid after clock advances past expiresAt', () => {
+      const t = store.issueToken(baseConfig, 'c', ['s']);
+      now += 101_000;
+      expect(store.isValid(baseConfig, t.accessToken)).toBe(false);
+    });
+
+    it('invalid when listed in config.tokens.revoked', () => {
+      const t = store.issueToken(baseConfig, 'c', ['s']);
+      const cfg: OAuthConfig = { ...baseConfig, tokens: { ...baseConfig.tokens, revoked: [t.accessToken] } };
+      expect(store.isValid(cfg, t.accessToken)).toBe(false);
+    });
+
+    it('invalid when listed in config.tokens.expired', () => {
+      const t = store.issueToken(baseConfig, 'c', ['s']);
+      const cfg: OAuthConfig = { ...baseConfig, tokens: { ...baseConfig.tokens, expired: [t.accessToken] } };
+      expect(store.isValid(cfg, t.accessToken)).toBe(false);
+    });
+
+    it('invalid for unknown token', () => {
+      expect(store.isValid(baseConfig, 'nope')).toBe(false);
+    });
+  });
+
+  describe('refresh', () => {
+    it('issues new access token and keeps same refresh_token when rotation off', () => {
+      const t1 = store.issueToken(baseConfig, 'c', ['s']);
+      const t2 = store.refreshToken(baseConfig, t1.refreshToken!);
+      expect(t2).toBeDefined();
+      expect(t2!.refreshToken).toBe(t1.refreshToken);
+      expect(t2!.accessToken).not.toBe(t1.accessToken);
+      expect(store.isValid(baseConfig, t1.accessToken)).toBe(false);
+      expect(store.isValid(baseConfig, t2!.accessToken)).toBe(true);
+    });
+
+    it('rotates refresh_token when rotateRefreshToken=true and invalidates old one', () => {
+      const cfg: OAuthConfig = { ...baseConfig, tokens: { ...baseConfig.tokens, rotateRefreshToken: true } };
+      const t1 = store.issueToken(cfg, 'c', ['s']);
+      const t2 = store.refreshToken(cfg, t1.refreshToken!);
+      expect(t2!.refreshToken).not.toBe(t1.refreshToken);
+      expect(store.refreshToken(cfg, t1.refreshToken!)).toBeUndefined();
+    });
+
+    it('returns undefined for unknown refresh_token', () => {
+      expect(store.refreshToken(baseConfig, 'nope')).toBeUndefined();
+    });
+  });
+
+  describe('authorization codes', () => {
+    it('issues and consumes code once', () => {
+      const c = store.issueAuthCode(baseConfig, {
+        clientId: 'c', redirectUri: 'http://x', codeChallenge: 'cc', scopes: ['s']
+      });
+      expect(store.consumeAuthCode(c.code)).toBeDefined();
+      expect(store.consumeAuthCode(c.code)).toBeUndefined();
+    });
+
+    it('returns undefined once code is past TTL', () => {
+      const c = store.issueAuthCode(baseConfig, {
+        clientId: 'c', redirectUri: 'http://x', codeChallenge: 'cc', scopes: ['s']
+      });
+      now += 11 * 60 * 1000;
+      expect(store.consumeAuthCode(c.code)).toBeUndefined();
+    });
+
+    it('getAuthCode does not consume the code', () => {
+      const c = store.issueAuthCode(baseConfig, {
+        clientId: 'c', redirectUri: 'http://x', codeChallenge: 'cc', scopes: ['s']
+      });
+      expect(store.getAuthCode(c.code)).toBeDefined();
+      expect(store.getAuthCode(c.code)).toBeDefined();
+      expect(store.consumeAuthCode(c.code)).toBeDefined();
+      expect(store.getAuthCode(c.code)).toBeUndefined();
+    });
+  });
+
+  describe('control ops', () => {
+    it('revoke by access_token kills both sides', () => {
+      const t = store.issueToken(baseConfig, 'c', ['s']);
+      store.revoke(t.accessToken);
+      expect(store.isValid(baseConfig, t.accessToken)).toBe(false);
+      expect(store.refreshToken(baseConfig, t.refreshToken!)).toBeUndefined();
+    });
+
+    it('revoke by refresh_token kills both sides', () => {
+      const t = store.issueToken(baseConfig, 'c', ['s']);
+      store.revoke(t.refreshToken!);
+      expect(store.isValid(baseConfig, t.accessToken)).toBe(false);
+      expect(store.refreshToken(baseConfig, t.refreshToken!)).toBeUndefined();
+    });
+
+    it('forceExpire flips valid to invalid', () => {
+      const t = store.issueToken(baseConfig, 'c', ['s']);
+      store.forceExpire(t.accessToken);
+      expect(store.isValid(baseConfig, t.accessToken)).toBe(false);
+    });
+
+    it('reset wipes everything including deterministic indices', () => {
+      const cfg: OAuthConfig = {
+        ...baseConfig,
+        tokens: {
+          expiresInSeconds: 100, refreshable: true,
+          deterministic: { nextAccessTokens: ['a1', 'a2'] }
+        }
+      };
+      store.issueToken(cfg, 'c', ['s']);
+      store.reset();
+      const t = store.issueToken(cfg, 'c', ['s']);
+      expect(t.accessToken).toBe('a1');
+    });
+  });
+
+  describe('clients', () => {
+    it('getClient finds seeded clients', () => {
+      const cfg: OAuthConfig = {
+        ...baseConfig,
+        clients: [{ clientId: 'seed', redirectUris: ['http://x'], scope: 'mcp:read' }]
+      };
+      const c = store.getClient(cfg, 'seed');
+      expect(c?.client_id).toBe('seed');
+      expect(c?.redirect_uris).toEqual(['http://x']);
+      expect(c?.token_endpoint_auth_method).toBe('none');
+    });
+
+    it('registers public client without secret', () => {
+      const c = store.registerClient(baseConfig, {
+        redirect_uris: ['http://127.0.0.1:39999/callback'],
+        token_endpoint_auth_method: 'none'
+      });
+      expect(c.client_id).toBeDefined();
+      expect(c.client_secret).toBeUndefined();
+    });
+
+    it('registers confidential client with secret', () => {
+      const c = store.registerClient(baseConfig, {
+        redirect_uris: ['http://x'],
+        token_endpoint_auth_method: 'client_secret_post'
+      });
+      expect(c.client_secret).toBeDefined();
+    });
+
+    it('uses deterministic client_id and client_secret when configured', () => {
+      const cfg: OAuthConfig = {
+        ...baseConfig,
+        tokens: {
+          expiresInSeconds: 100, refreshable: true,
+          deterministic: { nextClientIds: ['cid-1'], nextClientSecrets: ['sec-1'] }
+        }
+      };
+      const c = store.registerClient(cfg, {
+        redirect_uris: ['http://x'],
+        token_endpoint_auth_method: 'client_secret_post'
+      });
+      expect(c.client_id).toBe('cid-1');
+      expect(c.client_secret).toBe('sec-1');
+    });
+  });
+});

--- a/src/oauth/store.ts
+++ b/src/oauth/store.ts
@@ -1,0 +1,230 @@
+import { randomBytes } from 'node:crypto';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import { Clock, OAuthConfig } from './types';
+
+const DEFAULT_EXPIRES_IN = 3600;
+const CODE_TTL_MS = 10 * 60 * 1000;
+
+export interface StoredToken {
+  accessToken: string;
+  refreshToken?: string;
+  clientId: string;
+  scopes: string[];
+  issuedAt: number;
+  expiresAt: number;
+}
+
+export interface StoredAuthCode {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scopes: string[];
+  expiresAt: number;
+}
+
+type DeterministicIndex =
+  | 'accessIdx'
+  | 'refreshIdx'
+  | 'codeIdx'
+  | 'clientIdIdx'
+  | 'clientSecretIdx';
+
+export class OAuthStore {
+  private tokens: Map<string, StoredToken> = new Map();
+  private refreshIndex: Map<string, string> = new Map();
+  private codes: Map<string, StoredAuthCode> = new Map();
+  private dynamicClients: Map<string, OAuthClientInformationFull> = new Map();
+
+  private accessIdx = 0;
+  private refreshIdx = 0;
+  private codeIdx = 0;
+  private clientIdIdx = 0;
+  private clientSecretIdx = 0;
+
+  constructor(private clock: Clock) {}
+
+  private nextDeterministic(queue: string[] | undefined, idxKey: DeterministicIndex): string | undefined {
+    if (!queue) return undefined;
+    const i = this[idxKey];
+    if (i >= queue.length) return undefined;
+    this[idxKey] = i + 1;
+    return queue[i];
+  }
+
+  private randomId(): string {
+    return randomBytes(16).toString('hex');
+  }
+
+  getClient(config: OAuthConfig, clientId: string): OAuthClientInformationFull | undefined {
+    const seeded = config.clients?.find(c => c.clientId === clientId);
+    if (seeded) {
+      return {
+        client_id: seeded.clientId,
+        client_secret: seeded.clientSecret,
+        redirect_uris: seeded.redirectUris,
+        scope: seeded.scope,
+        token_endpoint_auth_method: seeded.clientSecret ? 'client_secret_post' : 'none'
+      };
+    }
+    return this.dynamicClients.get(clientId);
+  }
+
+  registerClient(
+    config: OAuthConfig,
+    input: Omit<OAuthClientInformationFull, 'client_id' | 'client_id_issued_at'>
+  ): OAuthClientInformationFull {
+    const isPublic = input.token_endpoint_auth_method === 'none';
+    const clientId = this.nextDeterministic(config.tokens?.deterministic?.nextClientIds, 'clientIdIdx') ?? this.randomId();
+    const clientSecret = isPublic
+      ? undefined
+      : (input.client_secret ?? this.nextDeterministic(config.tokens?.deterministic?.nextClientSecrets, 'clientSecretIdx') ?? this.randomId());
+
+    const info: OAuthClientInformationFull = {
+      ...input,
+      client_id: clientId,
+      client_secret: clientSecret,
+      client_id_issued_at: Math.floor(this.clock() / 1000),
+      client_secret_expires_at: isPublic ? undefined : 0
+    };
+    this.dynamicClients.set(clientId, info);
+    return info;
+  }
+
+  issueAuthCode(
+    config: OAuthConfig,
+    params: { clientId: string; redirectUri: string; codeChallenge: string; scopes: string[] }
+  ): StoredAuthCode {
+    const code = this.nextDeterministic(config.tokens?.deterministic?.nextAuthorizationCodes, 'codeIdx') ?? this.randomId();
+    const entry: StoredAuthCode = {
+      code,
+      clientId: params.clientId,
+      redirectUri: params.redirectUri,
+      codeChallenge: params.codeChallenge,
+      scopes: params.scopes,
+      expiresAt: this.clock() + CODE_TTL_MS
+    };
+    this.codes.set(code, entry);
+    return entry;
+  }
+
+  getAuthCode(code: string): StoredAuthCode | undefined {
+    this.evictExpiredCodes();
+    return this.codes.get(code);
+  }
+
+  consumeAuthCode(code: string): StoredAuthCode | undefined {
+    this.evictExpiredCodes();
+    const entry = this.codes.get(code);
+    if (!entry) return undefined;
+    this.codes.delete(code);
+    if (entry.expiresAt < this.clock()) return undefined;
+    return entry;
+  }
+
+  private evictExpiredCodes(): void {
+    const now = this.clock();
+    for (const [code, entry] of this.codes) {
+      if (entry.expiresAt < now) {
+        this.codes.delete(code);
+      }
+    }
+  }
+
+  issueToken(config: OAuthConfig, clientId: string, scopes: string[]): StoredToken {
+    const expiresIn = config.tokens?.expiresInSeconds ?? DEFAULT_EXPIRES_IN;
+    const refreshable = config.tokens?.refreshable ?? true;
+    const accessToken = this.nextDeterministic(config.tokens?.deterministic?.nextAccessTokens, 'accessIdx') ?? this.randomId();
+    const refreshToken = refreshable
+      ? (this.nextDeterministic(config.tokens?.deterministic?.nextRefreshTokens, 'refreshIdx') ?? this.randomId())
+      : undefined;
+    const now = this.clock();
+    const token: StoredToken = {
+      accessToken,
+      refreshToken,
+      clientId,
+      scopes,
+      issuedAt: now,
+      expiresAt: now + expiresIn * 1000
+    };
+    this.tokens.set(accessToken, token);
+    if (refreshToken) {
+      this.refreshIndex.set(refreshToken, accessToken);
+    }
+    return token;
+  }
+
+  refreshToken(config: OAuthConfig, refreshToken: string): StoredToken | undefined {
+    const accessToken = this.refreshIndex.get(refreshToken);
+    if (!accessToken) return undefined;
+    const existing = this.tokens.get(accessToken);
+    if (!existing) {
+      this.refreshIndex.delete(refreshToken);
+      return undefined;
+    }
+
+    const rotate = config.tokens?.rotateRefreshToken ?? false;
+
+    this.tokens.delete(existing.accessToken);
+    if (rotate) {
+      this.refreshIndex.delete(refreshToken);
+    }
+
+    const next = this.issueToken(config, existing.clientId, existing.scopes);
+
+    if (!rotate && next.refreshToken) {
+      this.refreshIndex.delete(next.refreshToken);
+      this.tokens.delete(next.accessToken);
+      const reused: StoredToken = { ...next, refreshToken };
+      this.tokens.set(reused.accessToken, reused);
+      this.refreshIndex.set(refreshToken, reused.accessToken);
+      return reused;
+    }
+    return next;
+  }
+
+  getToken(accessToken: string): StoredToken | undefined {
+    return this.tokens.get(accessToken);
+  }
+
+  isValid(config: OAuthConfig, accessToken: string): boolean {
+    const t = this.tokens.get(accessToken);
+    if (!t) return false;
+    if (config.tokens?.revoked?.includes(accessToken)) return false;
+    if (config.tokens?.expired?.includes(accessToken)) return false;
+    if (t.expiresAt < this.clock()) return false;
+    return true;
+  }
+
+  revoke(tokenValue: string): void {
+    if (this.tokens.has(tokenValue)) {
+      const t = this.tokens.get(tokenValue)!;
+      this.tokens.delete(tokenValue);
+      if (t.refreshToken) this.refreshIndex.delete(t.refreshToken);
+      return;
+    }
+    const access = this.refreshIndex.get(tokenValue);
+    if (access) {
+      this.refreshIndex.delete(tokenValue);
+      this.tokens.delete(access);
+    }
+  }
+
+  forceExpire(accessToken: string): void {
+    const t = this.tokens.get(accessToken);
+    if (!t) return;
+    t.expiresAt = this.clock() - 1;
+  }
+
+  reset(): void {
+    this.tokens.clear();
+    this.refreshIndex.clear();
+    this.codes.clear();
+    this.dynamicClients.clear();
+    this.accessIdx = 0;
+    this.refreshIdx = 0;
+    this.codeIdx = 0;
+    this.clientIdIdx = 0;
+    this.clientSecretIdx = 0;
+  }
+}

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -1,0 +1,40 @@
+export interface OAuthDeterministic {
+  nextAccessTokens?: string[];
+  nextRefreshTokens?: string[];
+  nextAuthorizationCodes?: string[];
+  nextClientIds?: string[];
+  nextClientSecrets?: string[];
+}
+
+export interface OAuthTokensConfig {
+  expiresInSeconds?: number;
+  refreshable?: boolean;
+  rotateRefreshToken?: boolean;
+  revoked?: string[];
+  expired?: string[];
+  deterministic?: OAuthDeterministic;
+}
+
+export interface OAuthSeedClient {
+  clientId: string;
+  clientSecret?: string;
+  redirectUris: string[];
+  scope?: string;
+}
+
+export interface OAuthMetadataConfig {
+  resourceName?: string;
+  scopesSupported?: string[];
+  registrationEndpointEnabled?: boolean;
+  issuerOverride?: string;
+  resourcePath?: string;
+}
+
+export interface OAuthConfig {
+  protectedPaths: string[];
+  clients?: OAuthSeedClient[];
+  tokens?: OAuthTokensConfig;
+  metadata?: OAuthMetadataConfig;
+}
+
+export type Clock = () => number;

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { renderTemplate } from './template';
 import { printConfigSummary } from './config-logger';
 import { setupA2ARoutes } from './a2a/routes';
 import { setupHttpMcpServer } from './mcp/http-server';
+import { setupOAuth } from './oauth';
 import { streamResponse } from './streaming';
 
 export function createServer(initialConfig: Config, host: string, port: number) {
@@ -25,6 +26,9 @@ export function createServer(initialConfig: Config, host: string, port: number) 
     console.log(`${req.method} ${req.path}`);
     next();
   });
+
+  // OAuth must be wired before MCP so the Bearer gate runs first.
+  setupOAuth(app, () => currentConfig, { host, port });
 
   // Setup A2A and MCP routes
   setupA2ARoutes(app, host, port);


### PR DESCRIPTION
## Summary

- Adds an OAuth 2.1 authorization server in front of the MCP endpoint so consumers (Ark `mcp-auth-cli-authorize` in particular) can test OAuth-protected MCP servers end-to-end without hitting real IdPs.
- Built on `@modelcontextprotocol/sdk`'s `mcpAuthRouter` — serves RFC 8414 / RFC 9728 discovery, RFC 7591 Dynamic Client Registration, Authorization Code + PKCE S256, and refresh-token flows. Bearer gate with RFC 9728 `WWW-Authenticate` challenge.
- Fixture-only control endpoints (`/oauth/reset`, `/oauth/revoke`, `/oauth/expire`, `/oauth/issue`) let tests drive state transitions without running the full flow. Tokens, codes, client_ids and client_secrets can be issued from deterministic queues for exact-value asserts.
- OAuth is opt-in via an `oauth` block on the existing config — all existing samples continue to pass unmodified.
- Three new samples (`14-mcp-oauth-discovery.sh`, `15-mcp-oauth-pkce-flow.sh`, `16-mcp-oauth-refresh.sh`) plus 34 unit tests covering store, control endpoints, and end-to-end integration.
- README + new `docs/mcp-oauth.md` document the config schema, control endpoints, and known gotchas.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` — 120/120 pass, 92% statement coverage on `src/oauth/*`.
- [x] `npm run test:samples` — 15/15 pass (12 existing + 3 new).
- [x] Manual run of sample 14 (discovery + 401 challenge)
- [x] Manual run of sample 15 (DCR + PKCE flow)
- [x] Manual run of sample 16 (refresh + revoke + force-expire)