### PR TITLE
feat(oauth): add allowInsecureIssuer flag for cluster-DNS fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ chainsaw test ./tests/my-test \
   --values image.repository=mock-llm,image.tag=local,image.pullPolicy=Never
 ```
 
+When mock-llm acts as an OAuth fixture inside the cluster, the issuer is a cluster DNS name (not HTTPS, not loopback) which the MCP SDK rejects by default. Opt in with `metadata.allowInsecureIssuer: true` — see [Insecure issuer mode](docs/mcp-oauth.md#insecure-issuer-mode-test-fixtures-only) for a values.yaml example.
+
 ## Samples
 
 Each sample below is in the form of an extremely minimal script that shows:

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -67,9 +67,28 @@ oauth:
     registrationEndpointEnabled: true        # default — set false to hide /register
     issuerOverride: "http://localhost:6556/" # default computed from host + port
     resourcePath: "/mcp"                     # default
+    allowInsecureIssuer: false               # default — see "Insecure issuer mode" below
 ```
 
-Only `issuerOverride` and `resourcePath` are read at server boot; everything else is evaluated per request so you can flip state mid-test via `PATCH /config`.
+Only `issuerOverride`, `resourcePath`, and `allowInsecureIssuer` are read at server boot; everything else is evaluated per request so you can flip state mid-test via `PATCH /config`.
+
+## Insecure issuer mode (test fixtures only)
+
+The MCP SDK's `mcpAuthRouter` enforces RFC 8414 by rejecting any issuer URL that is neither HTTPS nor `localhost`/`127.0.0.1`. When mock-llm runs inside Kubernetes as a fixture, the natural issuer is the cluster DNS name (e.g. `http://mock-llm.test-ns.svc.cluster.local:6556`), which is neither. Adding TLS to a test fixture is disproportionate.
+
+Setting `metadata.allowInsecureIssuer: true` opts out of the SDK's router and mounts the SDK's exported handlers directly with metadata mock-llm builds itself. The emitted `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` documents are structurally identical to the SDK's output (covered by a parity test).
+
+```yaml
+# mock-llm-values.yaml for a Kubernetes fixture
+config:
+  oauth:
+    protectedPaths: ["/mcp"]
+    metadata:
+      allowInsecureIssuer: true
+      issuerOverride: "http://mock-llm.test-ns.svc.cluster.local:6556/"
+```
+
+**Do not enable this in anything resembling production.** The flag is intended for integration test fixtures in ephemeral namespaces only. The default (`false`) preserves the SDK's strict HTTPS-only behaviour.
 
 ## Test control endpoints
 

--- a/src/oauth/index.spec.ts
+++ b/src/oauth/index.spec.ts
@@ -248,6 +248,129 @@ describe('oauth end-to-end', () => {
     });
   });
 
+  describe('allowInsecureIssuer', () => {
+    it('boots with a non-HTTPS, non-loopback issuer and serves equivalent metadata', async () => {
+      const clusterIssuer = 'http://mock-llm.test-ns.svc.cluster.local:6556/';
+      const cfg: Config = withOAuth({
+        protectedPaths: ['/mcp'],
+        metadata: {
+          allowInsecureIssuer: true,
+          issuerOverride: clusterIssuer
+        }
+      });
+      const insecureApp = createServer(cfg, 'localhost', 6556);
+      const insecureServer = insecureApp.listen(0);
+      const { port } = insecureServer.address() as { port: number };
+      try {
+        const asMeta = await fetch(`http://localhost:${port}/.well-known/oauth-authorization-server`)
+          .then(r => r.json() as Promise<Record<string, unknown>>);
+        expect(asMeta.issuer).toBe(clusterIssuer);
+        expect(asMeta.authorization_endpoint).toBe(`${clusterIssuer}authorize`);
+        expect(asMeta.token_endpoint).toBe(`${clusterIssuer}token`);
+        expect(asMeta.registration_endpoint).toBe(`${clusterIssuer}register`);
+        expect(asMeta.code_challenge_methods_supported).toEqual(['S256']);
+        expect(asMeta.grant_types_supported).toEqual(['authorization_code', 'refresh_token']);
+
+        const prmMeta = await fetch(`http://localhost:${port}/.well-known/oauth-protected-resource/mcp`)
+          .then(r => r.json() as Promise<Record<string, unknown>>);
+        expect(prmMeta.resource).toBe(`${clusterIssuer}mcp`);
+        expect(prmMeta.authorization_servers).toEqual([clusterIssuer]);
+        expect(prmMeta.resource_name).toBe('Mock MCP Resource');
+
+        // Bearer gate still challenges with RFC 9728 pointer to the cluster issuer.
+        const challenge = await fetch(`http://localhost:${port}/mcp/`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json, text/event-stream' },
+          body: PROBE_INIT
+        });
+        expect(challenge.status).toBe(401);
+        const wwwAuth = challenge.headers.get('www-authenticate')!;
+        expect(wwwAuth).toContain('resource_metadata=');
+        expect(wwwAuth).toContain(clusterIssuer);
+
+        // DCR still works via the manually mounted handler.
+        const dcr = await fetch(`http://localhost:${port}/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            client_name: 'insecure-test',
+            redirect_uris: ['http://127.0.0.1:0/cb'],
+            grant_types: ['authorization_code'],
+            response_types: ['code'],
+            token_endpoint_auth_method: 'none'
+          })
+        });
+        expect(dcr.status).toBe(201);
+      } finally {
+        insecureServer.close();
+      }
+    });
+
+    it('still accepts HTTPS issuers when the flag is set', async () => {
+      const cfg: Config = withOAuth({
+        protectedPaths: [],
+        metadata: {
+          allowInsecureIssuer: true,
+          issuerOverride: 'https://auth.example.com/'
+        }
+      });
+      const httpsApp = createServer(cfg, 'localhost', 6556);
+      const httpsServer = httpsApp.listen(0);
+      const { port } = httpsServer.address() as { port: number };
+      try {
+        const meta = await fetch(`http://localhost:${port}/.well-known/oauth-authorization-server`)
+          .then(r => r.json() as Promise<Record<string, unknown>>);
+        expect(meta.issuer).toBe('https://auth.example.com/');
+      } finally {
+        httpsServer.close();
+      }
+    });
+
+    it('still rejects a non-HTTPS, non-loopback issuer when the flag is absent', () => {
+      const cfg: Config = withOAuth({
+        protectedPaths: ['/mcp'],
+        metadata: { issuerOverride: 'http://mock-llm.test-ns.svc.cluster.local:6556/' }
+      });
+      // mcpAuthRouter throws synchronously during setup.
+      expect(() => createServer(cfg, 'localhost', 6556)).toThrow(/Issuer URL must be HTTPS/);
+    });
+
+    it('emits metadata structurally equivalent to the SDK router for a loopback issuer', async () => {
+      // Golden: SDK path with a loopback (HTTPS-exempt) issuer.
+      const sdkApp = createServer(withOAuth({
+        protectedPaths: ['/mcp'],
+        metadata: { issuerOverride: 'http://localhost:6556/' }
+      }), 'localhost', 6556);
+      const sdkServer = sdkApp.listen(0);
+      const sdkPort = (sdkServer.address() as { port: number }).port;
+
+      // Feature-on path with the same loopback issuer — output must match.
+      const insecureApp = createServer(withOAuth({
+        protectedPaths: ['/mcp'],
+        metadata: { allowInsecureIssuer: true, issuerOverride: 'http://localhost:6556/' }
+      }), 'localhost', 6556);
+      const insecureServer = insecureApp.listen(0);
+      const insecurePort = (insecureServer.address() as { port: number }).port;
+
+      try {
+        const [sdkAs, insecureAs] = await Promise.all([
+          fetch(`http://localhost:${sdkPort}/.well-known/oauth-authorization-server`).then(r => r.json()),
+          fetch(`http://localhost:${insecurePort}/.well-known/oauth-authorization-server`).then(r => r.json())
+        ]);
+        expect(insecureAs).toEqual(sdkAs);
+
+        const [sdkPrm, insecurePrm] = await Promise.all([
+          fetch(`http://localhost:${sdkPort}/.well-known/oauth-protected-resource/mcp`).then(r => r.json()),
+          fetch(`http://localhost:${insecurePort}/.well-known/oauth-protected-resource/mcp`).then(r => r.json())
+        ]);
+        expect(insecurePrm).toEqual(sdkPrm);
+      } finally {
+        sdkServer.close();
+        insecureServer.close();
+      }
+    });
+  });
+
   describe('refresh grant', () => {
     it('refresh issues a new access token and keeps original refresh_token when rotation is off', async () => {
       const cfg: Config = withOAuth({

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1,6 +1,12 @@
 import express from 'express';
 import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
+import { authorizationHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/authorize.js';
+import { tokenHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/token.js';
+import { clientRegistrationHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/register.js';
+import { metadataHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/metadata.js';
+import type { OAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { OAuthMetadata, OAuthProtectedResourceMetadata } from '@modelcontextprotocol/sdk/shared/auth.js';
 import { Config } from '../config';
 import { OAuthStore } from './store';
 import { OAuthConfig } from './types';
@@ -20,6 +26,69 @@ function resolveIssuer(initialOAuth: OAuthConfig | undefined, host: string, port
   }
   const safeHost = host === '0.0.0.0' || host === '::' ? 'localhost' : host;
   return new URL(`http://${safeHost}:${port}/`);
+}
+
+// Build RFC 8414 authorization server metadata matching the SDK's
+// createOAuthMetadata output shape. Kept in sync with the SDK by structural
+// parity tests in index.spec.ts.
+function buildAuthorizationServerMetadata(
+  issuerUrl: URL,
+  provider: OAuthServerProvider,
+  scopesSupported: string[]
+): OAuthMetadata {
+  const registrationEnabled = Boolean(provider.clientsStore.registerClient);
+  return {
+    issuer: issuerUrl.href,
+    authorization_endpoint: new URL('/authorize', issuerUrl).href,
+    response_types_supported: ['code'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint: new URL('/token', issuerUrl).href,
+    token_endpoint_auth_methods_supported: ['client_secret_post'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    scopes_supported: scopesSupported,
+    registration_endpoint: registrationEnabled ? new URL('/register', issuerUrl).href : undefined
+  };
+}
+
+function mountInsecureOAuthRouter(
+  app: express.Express,
+  provider: OAuthServerProvider,
+  issuerUrl: URL,
+  resourceServerUrl: URL,
+  scopesSupported: string[],
+  resourceName: string
+): void {
+  const authorizationServerMetadata = buildAuthorizationServerMetadata(
+    issuerUrl,
+    provider,
+    scopesSupported
+  );
+  const protectedResourceMetadata: OAuthProtectedResourceMetadata = {
+    resource: resourceServerUrl.href,
+    authorization_servers: [authorizationServerMetadata.issuer],
+    scopes_supported: scopesSupported,
+    resource_name: resourceName
+  };
+
+  const rsPath = new URL(resourceServerUrl.href).pathname;
+  app.use(
+    `/.well-known/oauth-protected-resource${rsPath === '/' ? '' : rsPath}`,
+    metadataHandler(protectedResourceMetadata)
+  );
+  app.use('/.well-known/oauth-authorization-server', metadataHandler(authorizationServerMetadata));
+
+  app.use('/authorize', authorizationHandler({ provider, rateLimit: false }));
+  app.use('/token', tokenHandler({ provider, rateLimit: false }));
+  if (authorizationServerMetadata.registration_endpoint) {
+    app.use(
+      '/register',
+      clientRegistrationHandler({
+        clientsStore: provider.clientsStore,
+        rateLimit: false,
+        clientIdGeneration: false
+      })
+    );
+  }
 }
 
 export function setupOAuth(
@@ -45,18 +114,24 @@ export function setupOAuth(
     issuerUrl
   ).href;
 
-  // Mount SDK OAuth router (authorize, token, register, well-known). Rate limits disabled
-  // for deterministic testing.
-  app.use(mcpAuthRouter({
-    provider,
-    issuerUrl,
-    resourceServerUrl,
-    scopesSupported,
-    resourceName,
-    authorizationOptions: { rateLimit: false },
-    tokenOptions: { rateLimit: false },
-    clientRegistrationOptions: { rateLimit: false, clientIdGeneration: false }
-  }));
+  // The SDK's mcpAuthRouter rejects non-HTTPS, non-loopback issuers at boot.
+  // Kubernetes cluster DNS (e.g. http://mock-llm.ns.svc.cluster.local:6556) is
+  // neither, so when the fixture opts in we mount the SDK's exported handlers
+  // directly with metadata we build ourselves.
+  if (initialOAuth?.metadata?.allowInsecureIssuer) {
+    mountInsecureOAuthRouter(app, provider, issuerUrl, resourceServerUrl, scopesSupported, resourceName);
+  } else {
+    app.use(mcpAuthRouter({
+      provider,
+      issuerUrl,
+      resourceServerUrl,
+      scopesSupported,
+      resourceName,
+      authorizationOptions: { rateLimit: false },
+      tokenOptions: { rateLimit: false },
+      clientRegistrationOptions: { rateLimit: false, clientIdGeneration: false }
+    }));
+  }
 
   // Dynamic Bearer gate: only challenges when current config lists the path.
   const gate = requireBearerAuth({ verifier: provider, resourceMetadataUrl });

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -28,6 +28,9 @@ export interface OAuthMetadataConfig {
   registrationEndpointEnabled?: boolean;
   issuerOverride?: string;
   resourcePath?: string;
+  // Permit non-HTTPS, non-loopback issuer URLs (e.g. Kubernetes cluster DNS).
+  // Test fixture only — must not be enabled in anything resembling production.
+  allowInsecureIssuer?: boolean;
 }
 
 export interface OAuthConfig {


### PR DESCRIPTION
## Summary
- `metadata.allowInsecureIssuer: true` bypasses `mcpAuthRouter` (which rejects non-HTTPS, non-loopback issuers) and mounts the SDK's exported handlers directly with metadata mock-llm builds. Unlocks mock-llm as an OAuth fixture reachable via Kubernetes cluster DNS (e.g. `http://mock-llm.<ns>.svc.cluster.local:6556`).
- Default behaviour (strict HTTPS-only) unchanged. Flag is test-fixture-only and documented as such.
- Parity test asserts emitted `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` are byte-equivalent to the SDK's output when both paths use a loopback issuer.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 148/148 pass
- [x] New tests in `src/oauth/index.spec.ts`: boots with cluster-DNS issuer, HTTPS issuer still works, default still rejects HTTP non-loopback, SDK-parity golden