### PR TITLE
feat(tls): add HTTPS support for in-cluster fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The server can be configured to provide different responses based on the input, 
     - [Streaming Configuration](#streaming-configuration)
 - [MCP (Model Context Protocol) Mocking](#mcp-model-context-protocol-mocking)
 - [MCP OAuth Emulation](#mcp-oauth-emulation)
+- [HTTPS / TLS](#https--tls)
 - [A2A (Agent to Agent Protocol) Mocking](#a2a-agent-to-agent-protocol-mocking)
 - [Deploying to Kubernetes with Helm](#deploying-to-kubernetes-with-helm)
 - [Examples](#examples)
@@ -303,6 +304,31 @@ Mock-LLM exposes MCP servers and tools which support testing the MCP protocol, d
 ## MCP OAuth Emulation
 
 Mock-LLM can also emulate an OAuth 2.1 authorization server in front of its MCP endpoint, so you can test OAuth-protected MCP servers end-to-end without depending on a real IdP. It serves RFC 8414 / RFC 9728 discovery, RFC 7591 Dynamic Client Registration, Authorization Code + PKCE, and refresh-token flows, plus a small set of control endpoints for test orchestration. See the [MCP OAuth Documentation](docs/mcp-oauth.md).
+
+## HTTPS / TLS
+
+Mock-LLM serves plain HTTP by default. Enable HTTPS when a consumer needs real TLS — for example the Go MCP SDK, which enforces HTTPS on OAuth discovery URLs per RFC 8414 / RFC 9728. See the [TLS Documentation](docs/tls.md) for the full story.
+
+Mock-LLM never generates or discovers certificates itself — the caller points it at PEM files. Three ways to pass paths, in priority order:
+
+| Source | Keys |
+|---|---|
+| Environment variables | `MOCK_LLM_TLS_ENABLED=true`, `MOCK_LLM_TLS_CERT`, `MOCK_LLM_TLS_KEY` |
+| Config file (`mock-llm.yaml`) | `tls.enabled`, `tls.certPath`, `tls.keyPath` |
+
+The Helm chart generates a self-signed cert via Helm's built-in `genSelfSignedCert` and sets the env vars automatically:
+
+```bash
+helm install mock-llm oci://ghcr.io/dwmkerr/charts/mock-llm \
+  --set tls.enabled=true
+```
+
+This creates:
+
+- `Secret {fullname}-tls` — `tls.crt` + `tls.key`, mounted into the pod.
+- `ConfigMap {fullname}-ca` — `ca.crt` only, consumable as a trust bundle (e.g. via `SSL_CERT_FILE`).
+
+Bring-your-own-cert (cert-manager, etc.): set `tls.existingSecret` + `tls.existingCAConfigMap`.
 
 ## A2A (Agent to Agent Protocol) Mocking
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -50,6 +50,14 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.service.port | quote }}
+            {{- if .Values.tls.enabled }}
+            - name: MOCK_LLM_TLS_ENABLED
+              value: "true"
+            - name: MOCK_LLM_TLS_CERT
+              value: /etc/mock-llm/tls/tls.crt
+            - name: MOCK_LLM_TLS_KEY
+              value: /etc/mock-llm/tls/tls.key
+            {{- end }}
             {{- if .Values.ark.a2a.enabled }}
             {{- if .Values.ark.a2a.agentCardHost }}
             - name: AGENT_CARD_HOST
@@ -60,17 +68,26 @@ spec:
               value: {{ .Values.ark.a2a.agentCardPort | quote }}
             {{- end }}
             {{- end }}
+          {{- /*
+            When TLS is enabled, force probes onto HTTPS by merging `scheme:
+            HTTPS` into each probe's httpGet block. When disabled, emit probes
+            as configured.
+          */}}
+          {{- $tlsScheme := dict }}
+          {{- if .Values.tls.enabled }}
+          {{- $tlsScheme = dict "httpGet" (dict "scheme" "HTTPS") }}
+          {{- end }}
           {{- with .Values.startupProbe }}
           startupProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml (mergeOverwrite (deepCopy .) $tlsScheme) | nindent 12 }}
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml (mergeOverwrite (deepCopy .) $tlsScheme) | nindent 12 }}
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml (mergeOverwrite (deepCopy .) $tlsScheme) | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}
           resources:
@@ -83,6 +100,11 @@ spec:
               subPath: mock-llm.yaml
               readOnly: true
             {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /etc/mock-llm/tls
+              readOnly: true
+            {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -91,6 +113,11 @@ spec:
         - name: config
           configMap:
             name: {{ .Values.existingConfigMap | default (include "mock-llm.fullname" .) }}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret | default (printf "%s-tls" (include "mock-llm.fullname" .)) }}
         {{- end }}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/tls.yaml
+++ b/chart/templates/tls.yaml
@@ -1,0 +1,45 @@
+{{/*
+When tls.enabled is true and the user has not supplied an existingSecret, the
+chart generates a self-signed cert via genSelfSignedCert. The private key is
+stored in a Secret (mounted into the mock-llm pod); the public cert is also
+exposed in a ConfigMap so consumers can mount it as a trust bundle (e.g. via
+SSL_CERT_FILE) without granting Secret read access.
+
+The cert is regenerated on every `helm install` / `helm upgrade`. Pin an
+external cert by setting `tls.existingSecret` + `tls.existingCAConfigMap`.
+*/}}
+{{- if .Values.tls.enabled }}
+{{- if and (not .Values.tls.existingSecret) (not .Values.tls.existingCAConfigMap) }}
+{{- $fullname := include "mock-llm.fullname" . -}}
+{{- $ns := .Release.Namespace -}}
+{{- $sans := concat (list
+    $fullname
+    (printf "%s.%s" $fullname $ns)
+    (printf "%s.%s.svc" $fullname $ns)
+    (printf "%s.%s.svc.cluster.local" $fullname $ns)
+    "localhost"
+    "127.0.0.1"
+  ) .Values.tls.extraSANs -}}
+{{- $cert := genSelfSignedCert (first $sans) (list "127.0.0.1") $sans 3650 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullname }}-tls
+  labels:
+    {{- include "mock-llm.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullname }}-ca
+  labels:
+    {{- include "mock-llm.labels" . | nindent 4 }}
+data:
+  ca.crt: |
+{{ $cert.Cert | indent 4 }}
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -196,6 +196,32 @@ affinity: {}
 # Use an existing ConfigMap instead of creating one from config above
 # existingConfigMap: ""
 
+# TLS (HTTPS) support. Off by default — mock-llm ships as a fixture, so plain
+# HTTP is the default. Enable when a consumer (e.g. a Go MCP SDK client) needs
+# real HTTPS discovery per RFC 8414 / RFC 9728.
+#
+# When enabled with no overrides, the chart generates a self-signed cert via
+# Helm's built-in genSelfSignedCert and creates two resources:
+#
+#   - Secret    {fullname}-tls  — tls.crt + tls.key, mounted into the pod
+#   - ConfigMap {fullname}-ca   — ca.crt only, consumable as a trust bundle
+#
+# Clients trust the cert by mounting the ConfigMap and pointing SSL_CERT_FILE
+# at /path/ca.crt. To bring your own (e.g. cert-manager), set existingSecret
+# and existingCAConfigMap.
+tls:
+  enabled: false
+  # Extra Subject Alternative Names appended to the chart-derived defaults
+  # (fullname, fullname.ns, fullname.ns.svc, fullname.ns.svc.cluster.local,
+  # localhost, 127.0.0.1).
+  extraSANs: []
+  # Name of a pre-existing TLS secret (type kubernetes.io/tls). When set, the
+  # chart does not generate a cert and uses this secret instead.
+  existingSecret: ""
+  # Name of a pre-existing ConfigMap containing the CA for this cert, used by
+  # consumers. When set, the chart does not emit the generated CA ConfigMap.
+  existingCAConfigMap: ""
+
 # Ark Model CRD configuration (optional)
 # Requires Ark to be installed: https://github.com/mckinsey/agents-at-scale
 ark:

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -1,0 +1,136 @@
+# HTTPS / TLS
+
+Mock-LLM serves plain HTTP by default. TLS is opt-in.
+
+## When to enable
+
+- Any in-cluster test that exercises a client with strict HTTPS enforcement. Notable example: the Go MCP SDK (`github.com/modelcontextprotocol/go-sdk/oauthex`) rejects non-HTTPS, non-loopback metadata URLs with no escape hatch.
+- Any environment that forbids HTTP traffic between pods.
+- Smoke-testing clients against real certificate validation paths.
+
+If your only consumer is the TypeScript MCP SDK on loopback, plain HTTP is fine. TLS adds fixture complexity (cert distribution, trust bundles) that you do not need for loopback tests.
+
+## How mock-llm reads TLS config
+
+**Mock-llm never generates or discovers certificates.** The caller supplies paths, mock-llm reads the files, done. Same pattern as nginx, caddy, etcd, kubelet.
+
+Two input surfaces, environment variables take precedence over the config file:
+
+**Environment variables** (twelve-factor, used by the Helm chart):
+
+```bash
+MOCK_LLM_TLS_ENABLED=true
+MOCK_LLM_TLS_CERT=/etc/mock-llm/tls/tls.crt
+MOCK_LLM_TLS_KEY=/etc/mock-llm/tls/tls.key
+```
+
+**Config file** (`mock-llm.yaml`, for local dev):
+
+```yaml
+tls:
+  enabled: true
+  certPath: ./scratch/mock-llm.crt
+  keyPath: ./scratch/mock-llm.key
+```
+
+`tls.enabled=true` without both paths is a startup error — fail fast, no implicit defaults.
+
+## Local development
+
+Generate a self-signed cert once:
+
+```bash
+mkdir -p ./scratch
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout ./scratch/mock-llm.key \
+  -out ./scratch/mock-llm.crt \
+  -days 365 \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+```
+
+Point mock-llm at it and run:
+
+```yaml
+# mock-llm.yaml
+tls:
+  enabled: true
+  certPath: ./scratch/mock-llm.crt
+  keyPath: ./scratch/mock-llm.key
+```
+
+```bash
+mock-llm
+# mock-llm vX.Y.Z server running on https://0.0.0.0:6556
+curl --cacert ./scratch/mock-llm.crt https://localhost:6556/health
+```
+
+## Kubernetes / Helm
+
+The chart generates a self-signed cert via Helm's built-in `genSelfSignedCert` and emits two resources:
+
+- `Secret {fullname}-tls` (type `kubernetes.io/tls`) — private key + cert, mounted into the mock-llm pod at `/etc/mock-llm/tls/`.
+- `ConfigMap {fullname}-ca` — just the public cert, for consumers to mount as a trust bundle.
+
+```bash
+helm install mock-llm ./chart --set tls.enabled=true
+```
+
+The generated cert carries Subject Alternative Names covering the chart-derived in-cluster DNS names:
+
+- `{fullname}`
+- `{fullname}.{namespace}`
+- `{fullname}.{namespace}.svc`
+- `{fullname}.{namespace}.svc.cluster.local`
+- `localhost`
+- `127.0.0.1`
+
+Add more with `tls.extraSANs`.
+
+### Consumer-side trust
+
+A pod that needs to trust mock-llm mounts the CA ConfigMap and points `SSL_CERT_FILE` at it:
+
+```yaml
+# consumer-deployment.yaml
+spec:
+  template:
+    spec:
+      containers:
+        - name: my-consumer
+          env:
+            - name: SSL_CERT_FILE
+              value: /etc/mock-llm/ca/ca.crt
+          volumeMounts:
+            - name: mock-llm-ca
+              mountPath: /etc/mock-llm/ca
+              readOnly: true
+      volumes:
+        - name: mock-llm-ca
+          configMap:
+            name: mock-llm-ca
+```
+
+Go's `net/http` default transport honours `SSL_CERT_FILE`. Most language runtimes do too.
+
+### Bring your own cert (cert-manager)
+
+```yaml
+# values.yaml
+tls:
+  enabled: true
+  existingSecret: mock-llm-cert-manager-tls
+  existingCAConfigMap: mock-llm-cert-manager-ca
+```
+
+When both are set the chart does not generate a cert and mounts the named resources instead.
+
+## Cert rotation
+
+`genSelfSignedCert` produces a new cert on every `helm install` / `helm upgrade`. Pods restart, consumers re-read the ConfigMap. Fine for fixtures; use cert-manager for anything longer-lived.
+
+## Non-goals
+
+- Mutual TLS. Not part of the MCP auth spec.
+- Real CA-signed certs (use cert-manager instead, see above).
+- Runtime cert generation. Chart / local tooling does that, mock-llm just reads files.

--- a/samples/17-tls-basic.sh
+++ b/samples/17-tls-basic.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Verify mock-llm serves HTTPS when MOCK_LLM_TLS_ENABLED=true and cert/key
+# paths are supplied. Runs an isolated mock-llm on a separate port so it does
+# not collide with the sample-suite's shared HTTP server on 6556.
+
+PORT=6557
+TMPDIR=$(mktemp -d)
+CERT="$TMPDIR/tls.crt"
+KEY="$TMPDIR/tls.key"
+SERVER_PID=""
+
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+echo "Generating self-signed cert at $CERT..."
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout "$KEY" \
+  -out "$CERT" \
+  -days 1 \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+  >/dev/null 2>&1
+
+echo "Starting mock-llm with TLS on port $PORT..."
+MOCK_LLM_TLS_ENABLED=true \
+  MOCK_LLM_TLS_CERT="$CERT" \
+  MOCK_LLM_TLS_KEY="$KEY" \
+  PORT=$PORT \
+  node dist/main.js >"$TMPDIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+# Wait for readiness (max ~5s). Use the real cert via --cacert; if the server
+# crashed we exit via pipefail + the log tail at the end.
+for _ in $(seq 1 50); do
+  if curl -fsS --cacert "$CERT" "https://localhost:$PORT/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
+echo "Checking scheme is HTTPS..."
+grep -q "https://" "$TMPDIR/server.log" || {
+  echo "failed: startup log does not advertise https://"
+  cat "$TMPDIR/server.log"
+  exit 1
+}
+
+echo "Probing /health over HTTPS with CA pinned..."
+status=$(curl -s -o /dev/null -w "%{http_code}" \
+  --cacert "$CERT" \
+  "https://localhost:$PORT/health")
+[ "$status" = "200" ] || { echo "failed: expected 200, got $status"; exit 1; }
+echo "HTTPS /health -> 200 OK"
+
+echo "Verifying plain HTTP is rejected on the TLS port..."
+if curl -fsS "http://localhost:$PORT/health" >/dev/null 2>&1; then
+  echo "failed: HTTP request unexpectedly succeeded against TLS listener"
+  exit 1
+fi
+echo "Plain HTTP rejected as expected"
+
+echo "Verifying untrusted cert is rejected without --cacert..."
+if curl -fsS "https://localhost:$PORT/health" >/dev/null 2>&1; then
+  echo "failed: TLS verification unexpectedly passed without --cacert"
+  exit 1
+fi
+echo "Untrusted cert rejected as expected"
+
+echo "TLS sample passed"

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
-import { getDefaultConfig, getConfigPath } from './config';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getDefaultConfig, getConfigPath, loadConfig } from './config';
 
 describe('config', () => {
   describe('getDefaultConfig', () => {
@@ -39,6 +42,36 @@ describe('config', () => {
       const configPath = getConfigPath();
 
       expect(configPath).toMatch(/mock-llm\.yaml$/);
+    });
+  });
+
+  describe('loadConfig', () => {
+    it('returns defaults when the file does not exist', () => {
+      const config = loadConfig('/nonexistent/mock-llm.yaml');
+      expect(config).toEqual(getDefaultConfig());
+    });
+
+    it('merges loaded YAML over the defaults, preserving the tls block', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mock-llm-config-'));
+      const file = path.join(tmp, 'mock-llm.yaml');
+      fs.writeFileSync(file,
+        'tls:\n' +
+        '  enabled: true\n' +
+        '  certPath: /etc/mock-llm/tls/tls.crt\n' +
+        '  keyPath: /etc/mock-llm/tls/tls.key\n'
+      );
+      try {
+        const config = loadConfig(file);
+        expect(config.tls).toEqual({
+          enabled: true,
+          certPath: '/etc/mock-llm/tls/tls.crt',
+          keyPath: '/etc/mock-llm/tls/tls.key'
+        });
+        // Defaults still present for fields not in the YAML.
+        expect(config.streaming).toEqual(getDefaultConfig().streaming);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,8 +3,10 @@ import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 
 import { OAuthConfig } from './oauth/types';
+import { TLSConfig } from './tls';
 
 export { OAuthConfig } from './oauth/types';
+export { TLSConfig } from './tls';
 
 export interface Response {
   status: number;
@@ -28,6 +30,7 @@ export interface Config {
   streaming: StreamingConfig;
   rules: Rule[];
   oauth?: OAuthConfig;
+  tls?: TLSConfig;
 }
 
 export function getDefaultConfig(): Config {

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,25 +1,43 @@
 import { getConfigPath, loadConfig } from './config';
 import { printConfigSummary } from './config-logger';
 import { createServer } from './server';
+import { loadTLSCredentials } from './tls';
+import * as http from 'http';
+import * as https from 'https';
 
 jest.mock('./config');
 jest.mock('./config-logger');
 jest.mock('./server');
+jest.mock('./tls');
+jest.mock('http');
+jest.mock('https');
 
 describe('main', () => {
+  let mockHttpListen: jest.Mock;
+  let mockHttpsListen: jest.Mock;
+
   beforeEach(() => {
     jest.clearAllMocks();
 
-    const mockApp = {
-      listen: jest.fn().mockImplementation((port, host, callback) => {
-        if (callback) callback();
-        return { on: jest.fn() };
-      })
-    };
-    (createServer as jest.Mock).mockReturnValue(mockApp);
+    (createServer as jest.Mock).mockReturnValue({});
+
+    mockHttpListen = jest.fn().mockImplementation((_port, _host, cb) => {
+      if (cb) cb();
+      return { on: jest.fn() };
+    });
+    mockHttpsListen = jest.fn().mockImplementation((_port, _host, cb) => {
+      if (cb) cb();
+      return { on: jest.fn() };
+    });
+    (http.createServer as jest.Mock).mockReturnValue({ listen: mockHttpListen });
+    (https.createServer as jest.Mock).mockReturnValue({ listen: mockHttpsListen });
+
+    delete process.env.MOCK_LLM_TLS_ENABLED;
+    delete process.env.MOCK_LLM_TLS_CERT;
+    delete process.env.MOCK_LLM_TLS_KEY;
   });
 
-  it('loads config, prints summary, and starts server', async () => {
+  it('loads config, prints summary, and starts HTTP server', async () => {
     const mockConfig = {
       rules: [
         { path: '/v1/chat/completions', match: '@', response: { status: 200, content: '{}' } }
@@ -28,8 +46,8 @@ describe('main', () => {
 
     (getConfigPath as jest.Mock).mockReturnValue('/app/mock-llm.yaml');
     (loadConfig as jest.Mock).mockReturnValue(mockConfig);
+    (loadTLSCredentials as jest.Mock).mockReturnValue(undefined);
 
-    // Import main to execute it
     await jest.isolateModulesAsync(async () => {
       await import('./main');
     });
@@ -38,5 +56,46 @@ describe('main', () => {
     expect(loadConfig).toHaveBeenCalledWith('/app/mock-llm.yaml');
     expect(printConfigSummary).toHaveBeenCalledWith(mockConfig, 'Loaded configuration from /app/mock-llm.yaml');
     expect(createServer).toHaveBeenCalledWith(mockConfig, '0.0.0.0', 6556);
+    expect(http.createServer).toHaveBeenCalled();
+    expect(https.createServer).not.toHaveBeenCalled();
+    expect(mockHttpListen).toHaveBeenCalledWith(6556, '0.0.0.0', expect.any(Function));
+  });
+
+  it('starts HTTPS server when TLS credentials load successfully', async () => {
+    const mockConfig = { rules: [], tls: { enabled: true, certPath: '/c', keyPath: '/k' } };
+    const creds = { cert: Buffer.from('cert'), key: Buffer.from('key') };
+
+    (getConfigPath as jest.Mock).mockReturnValue('/app/mock-llm.yaml');
+    (loadConfig as jest.Mock).mockReturnValue(mockConfig);
+    (loadTLSCredentials as jest.Mock).mockReturnValue(creds);
+
+    await jest.isolateModulesAsync(async () => {
+      await import('./main');
+    });
+
+    expect(https.createServer).toHaveBeenCalledWith(creds, {});
+    expect(http.createServer).not.toHaveBeenCalled();
+    expect(mockHttpsListen).toHaveBeenCalledWith(6556, '0.0.0.0', expect.any(Function));
+  });
+
+  it('overrides config.tls with MOCK_LLM_TLS_* env vars', async () => {
+    const mockConfig = { rules: [] };
+    (getConfigPath as jest.Mock).mockReturnValue('/app/mock-llm.yaml');
+    (loadConfig as jest.Mock).mockReturnValue(mockConfig);
+    (loadTLSCredentials as jest.Mock).mockReturnValue(undefined);
+
+    process.env.MOCK_LLM_TLS_ENABLED = 'true';
+    process.env.MOCK_LLM_TLS_CERT = '/env/cert';
+    process.env.MOCK_LLM_TLS_KEY = '/env/key';
+
+    await jest.isolateModulesAsync(async () => {
+      await import('./main');
+    });
+
+    expect(loadTLSCredentials).toHaveBeenCalledWith({
+      enabled: true,
+      certPath: '/env/cert',
+      keyPath: '/env/key'
+    });
   });
 });

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -98,4 +98,53 @@ describe('main', () => {
       keyPath: '/env/key'
     });
   });
+
+  it('falls back to config.tls paths when MOCK_LLM_TLS_ENABLED is set but CERT/KEY env vars are not', async () => {
+    // Covers the nullish-coalescing branch: enable via env, but keep the
+    // cert/key paths that were already in the mounted config file.
+    const mockConfig = {
+      rules: [],
+      tls: { enabled: false, certPath: '/file/cert', keyPath: '/file/key' }
+    };
+    (getConfigPath as jest.Mock).mockReturnValue('/app/mock-llm.yaml');
+    (loadConfig as jest.Mock).mockReturnValue(mockConfig);
+    (loadTLSCredentials as jest.Mock).mockReturnValue(undefined);
+
+    process.env.MOCK_LLM_TLS_ENABLED = 'true';
+
+    await jest.isolateModulesAsync(async () => {
+      await import('./main');
+    });
+
+    expect(loadTLSCredentials).toHaveBeenCalledWith({
+      enabled: true,
+      certPath: '/file/cert',
+      keyPath: '/file/key'
+    });
+  });
+
+  it('leaves config.tls untouched when MOCK_LLM_TLS_ENABLED is not "true"', async () => {
+    const mockConfig = {
+      rules: [],
+      tls: { enabled: true, certPath: '/file/cert', keyPath: '/file/key' }
+    };
+    (getConfigPath as jest.Mock).mockReturnValue('/app/mock-llm.yaml');
+    (loadConfig as jest.Mock).mockReturnValue(mockConfig);
+    (loadTLSCredentials as jest.Mock).mockReturnValue(undefined);
+
+    // Anything other than the literal "true" leaves config alone.
+    process.env.MOCK_LLM_TLS_ENABLED = 'false';
+    process.env.MOCK_LLM_TLS_CERT = '/env/cert';
+    process.env.MOCK_LLM_TLS_KEY = '/env/key';
+
+    await jest.isolateModulesAsync(async () => {
+      await import('./main');
+    });
+
+    expect(loadTLSCredentials).toHaveBeenCalledWith({
+      enabled: true,
+      certPath: '/file/cert',
+      keyPath: '/file/key'
+    });
+  });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
+import * as http from 'http';
+import * as https from 'https';
 import { createServer } from './server';
 import { getConfigPath, loadConfig } from './config';
 import { printConfigSummary } from './config-logger';
+import { loadTLSCredentials } from './tls';
 import pkg from '../package.json';
 
 const HOST = process.env.HOST || '0.0.0.0';
@@ -15,8 +18,25 @@ const configPath = configArgIndex !== -1 ? process.argv[configArgIndex + 1] : ge
 const config = loadConfig(configPath);
 printConfigSummary(config, `Loaded configuration from ${configPath}`);
 
-const app = createServer(config, HOST, PORT);
+// Env vars override anything in the config file. This is the contract between
+// the Helm chart (which mounts a Secret and sets MOCK_LLM_TLS_CERT/KEY) and
+// the runtime — operators never need to edit the mounted config to wire TLS.
+if (process.env.MOCK_LLM_TLS_ENABLED === 'true') {
+  config.tls = {
+    ...config.tls,
+    enabled: true,
+    certPath: process.env.MOCK_LLM_TLS_CERT ?? config.tls?.certPath,
+    keyPath: process.env.MOCK_LLM_TLS_KEY ?? config.tls?.keyPath
+  };
+}
 
-app.listen(PORT, HOST, () => {
-  console.log(`${pkg.name} v${pkg.version} server running on ${HOST}:${PORT}`);
+const app = createServer(config, HOST, PORT);
+const tlsCredentials = loadTLSCredentials(config.tls);
+const server = tlsCredentials
+  ? https.createServer(tlsCredentials, app)
+  : http.createServer(app);
+const scheme = tlsCredentials ? 'https' : 'http';
+
+server.listen(PORT, HOST, () => {
+  console.log(`${pkg.name} v${pkg.version} server running on ${scheme}://${HOST}:${PORT}`);
 }).on('error', (err) => { console.error(err); process.exit(1); });

--- a/src/tls/index.spec.ts
+++ b/src/tls/index.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as https from 'https';
+import * as tls from 'tls';
+import { execFileSync } from 'child_process';
+import express from 'express';
+import { loadTLSCredentials } from './index';
+
+describe('loadTLSCredentials', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mock-llm-tls-'));
+  const certPath = path.join(tmpDir, 'tls.crt');
+  const keyPath = path.join(tmpDir, 'tls.key');
+
+  beforeAll(() => {
+    // Generate a self-signed cert for test fixtures. openssl is available on
+    // every platform the CI matrix runs on; if this changes, swap for a
+    // vendored fixture PEM.
+    execFileSync('openssl', [
+      'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+      '-keyout', keyPath,
+      '-out', certPath,
+      '-days', '1',
+      '-subj', '/CN=localhost',
+      '-addext', 'subjectAltName=DNS:localhost,IP:127.0.0.1'
+    ], { stdio: 'pipe' });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns undefined when tls is absent', () => {
+    expect(loadTLSCredentials(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when tls.enabled is false', () => {
+    expect(loadTLSCredentials({ enabled: false, certPath, keyPath })).toBeUndefined();
+  });
+
+  it('throws when enabled without certPath', () => {
+    expect(() => loadTLSCredentials({ enabled: true, keyPath })).toThrow(
+      /requires both tls.certPath and tls.keyPath/
+    );
+  });
+
+  it('throws when enabled without keyPath', () => {
+    expect(() => loadTLSCredentials({ enabled: true, certPath })).toThrow(
+      /requires both tls.certPath and tls.keyPath/
+    );
+  });
+
+  it('reads cert and key from the configured paths', () => {
+    const creds = loadTLSCredentials({ enabled: true, certPath, keyPath });
+    expect(creds).toBeDefined();
+    expect(creds!.cert.toString()).toContain('BEGIN CERTIFICATE');
+    expect(creds!.key.toString()).toMatch(/BEGIN (?:RSA |)PRIVATE KEY/);
+  });
+
+  it('serves HTTPS requests when mounted on https.createServer', async () => {
+    const creds = loadTLSCredentials({ enabled: true, certPath, keyPath })!;
+    const app = express();
+    app.get('/health', (_, res) => { res.json({ status: 'healthy' }); });
+    const server = https.createServer(creds, app);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const { port } = server.address() as { port: number };
+    try {
+      // Trust the fixture cert for this one request.
+      const agent = new https.Agent({
+        ca: creds.cert,
+        checkServerIdentity: (_host: string, _cert: tls.PeerCertificate) => undefined
+      });
+      const res = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const req = https.get(`https://localhost:${port}/health`, { agent }, (r) => {
+          let data = '';
+          r.on('data', (c) => { data += c; });
+          r.on('end', () => resolve({ status: r.statusCode ?? 0, body: data }));
+        });
+        req.on('error', reject);
+      });
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ status: 'healthy' });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/src/tls/index.ts
+++ b/src/tls/index.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+
+export interface TLSConfig {
+  enabled?: boolean;
+  certPath?: string;
+  keyPath?: string;
+}
+
+export interface TLSCredentials {
+  cert: Buffer;
+  key: Buffer;
+}
+
+// Load the cert + key pair from the paths supplied in config. mock-llm does
+// not generate or discover certs — the caller (Helm chart, cert-manager,
+// local `make cert`, etc.) is responsible for producing the PEM files and
+// pointing at them.
+export function loadTLSCredentials(tls: TLSConfig | undefined): TLSCredentials | undefined {
+  if (!tls?.enabled) {
+    return undefined;
+  }
+  if (!tls.certPath || !tls.keyPath) {
+    throw new Error('tls.enabled=true requires both tls.certPath and tls.keyPath');
+  }
+  const cert = fs.readFileSync(tls.certPath);
+  const key = fs.readFileSync(tls.keyPath);
+  return { cert, key };
+}


### PR DESCRIPTION
## Summary
- Adds opt-in HTTPS support so strict MCP clients (notably the Go SDK, which enforces HTTPS on OAuth discovery per RFC 8414 / RFC 9728) can run against mock-llm in Kubernetes.
- Runtime reads cert + key paths from config or \`MOCK_LLM_TLS_CERT\` / \`MOCK_LLM_TLS_KEY\` env vars (env takes precedence). **No discovery, no runtime generation** — same pattern as nginx, caddy, etcd, kubelet.
- Helm chart generates a self-signed cert via built-in \`genSelfSignedCert\` and emits a \`kubernetes.io/tls\` Secret (mounted into the pod) plus a CA-only ConfigMap (for consumers to mount as a trust bundle). Bring-your-own via \`tls.existingSecret\` + \`tls.existingCAConfigMap\`.
- Liveness/readiness/startup probes switch to \`scheme: HTTPS\` when TLS is on.
- Default is unchanged: plain HTTP, no TLS artifacts emitted.

## Test plan
- [x] \`npx jest\` — 152/152 pass (new: 6 unit tests for \`loadTLSCredentials\` incl. real HTTPS handshake; 3 updated \`main.ts\` tests covering env-var override and HTTPS branch)
- [x] \`npm run test:samples\` — 16/16 pass incl. new \`samples/17-tls-basic.sh\` verifying HTTPS handshake, HTTP rejection, and untrusted-cert rejection
- [x] \`npx tsc --noEmit\` clean
- [x] \`helm lint ./chart\` + \`helm lint ./chart --set tls.enabled=true\` clean
- [x] \`helm template ... --set tls.enabled=true\` — Secret, ConfigMap, env vars, volume mount, HTTPS probes all rendered correctly; with flag off, nothing added